### PR TITLE
#22470 (2). DMP閲覧画面の実装※表示内容はダミー

### DIFF
--- a/app/adapters/dmp-status.ts
+++ b/app/adapters/dmp-status.ts
@@ -1,0 +1,33 @@
+import DS from 'ember-data';
+import config from 'ember-get-config';
+import OsfAdapter from './osf-adapter';
+
+const {
+    OSF: {
+        url: host,
+        webApiNamespace: namespace,
+    },
+} = config;
+
+export default class DMPStatusAdapter extends OsfAdapter {
+    host = host.replace(/\/+$/, '');
+    namespace = namespace;
+
+    buildURL(
+        _: string | undefined,
+        id: string | null,
+        __: DS.Snapshot | null,
+        ___: string,
+        ____?: {},
+    ): string {
+        const nodeUrl = super.buildURL('node', null, null, 'findRecord', {});
+        const url = nodeUrl.replace(/\/nodes\/$/, '/project/');
+        return `${url}${id}/niirdccore/dmp`;
+    }
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        'dmp-status': DMPStatusAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/guid-node/niirdccore/controller.ts
+++ b/app/guid-node/niirdccore/controller.ts
@@ -1,0 +1,109 @@
+import Controller from '@ember/controller';
+import EmberError from '@ember/error';
+import { action, computed } from '@ember/object';
+import { reads } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+
+import DS from 'ember-data';
+
+import Intl from 'ember-intl/services/intl';
+import DMPStatusModel from 'ember-osf-web/models/dmp-status';
+import Node from 'ember-osf-web/models/node';
+import Analytics from 'ember-osf-web/services/analytics';
+import StatusMessages from 'ember-osf-web/services/status-messages';
+import Toast from 'ember-toastr/services/toast';
+
+export default class GuidNode_niirdccore extends Controller {
+    @service toast!: Toast;
+    @service intl!: Intl;
+    @service statusMessages!: StatusMessages;
+    @service analytics!: Analytics;
+
+    @reads('model.taskInstance.value')
+    node?: Node;
+
+    isPageDirty = false;
+
+    configCache?: DS.PromiseObject<DMPStatusModel>;
+
+    @computed('config.isFulfilled')
+    get loading(): boolean {
+        return !this.config || !this.config.get('isFulfilled');
+    }
+
+    @action
+    save(this: GuidNode_niirdccore) {
+        if (!this.config) {
+            throw new EmberError('Illegal config');
+        }
+        const config = this.config.content as DMPStatusModel;
+
+        config.save()
+            .then(() => {
+                this.set('isPageDirty', false);
+            })
+            .catch(() => {
+                this.saveError(config);
+            });
+    }
+
+    saveError(config: DMPStatusModel) {
+        config.rollbackAttributes();
+        const message = 'failed to save';
+        this.toast.error(message);
+    }
+
+    @computed('config.name')
+    get name2() {
+        if (!this.config || !this.config.get('isFulfilled')) {
+            return '';
+        }
+        const config = this.config.content as DMPStatusModel;
+        return config.name;
+    }
+
+    @computed('config.mbox')
+    get mbox() {
+        if (!this.config || !this.config.get('isFulfilled')) {
+            return '';
+        }
+        const config = this.config.content as DMPStatusModel;
+        return config.mbox;
+    }
+
+    @computed('config.title')
+    get title() {
+        if (!this.config || !this.config.get('isFulfilled')) {
+            return '';
+        }
+        const config = this.config.content as DMPStatusModel;
+        return config.title;
+    }
+
+    @computed('config.description')
+    get description() {
+        if (!this.config || !this.config.get('isFulfilled')) {
+            return '';
+        }
+        const config = this.config.content as DMPStatusModel;
+        return config.description;
+    }
+
+    @computed('node')
+    get config(): DS.PromiseObject<DMPStatusModel> | undefined {
+        if (this.configCache) {
+            return this.configCache;
+        }
+        if (!this.node) {
+            return undefined;
+        }
+        this.configCache = this.store.findRecord('dmp-status', this.node.id);
+        return this.configCache!;
+    }
+}
+
+declare module '@ember/controller' {
+    interface Registry {
+        'guid-node/niirdccore': GuidNode_niirdccore;
+    }
+}

--- a/app/guid-node/niirdccore/route.ts
+++ b/app/guid-node/niirdccore/route.ts
@@ -1,0 +1,33 @@
+import { action, computed } from '@ember/object';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import ConfirmationMixin from 'ember-onbeforeunload/mixins/confirmation';
+
+import GuidNode_niirdccore from 'ember-osf-web/guid-node/niirdccore/controller';
+import Node from 'ember-osf-web/models/node';
+import { GuidRouteModel } from 'ember-osf-web/resolve-guid/guid-route';
+import Analytics from 'ember-osf-web/services/analytics';
+
+export default class GuidNode_niirdccoreRoute extends Route.extend(ConfirmationMixin, {}) {
+    @service analytics!: Analytics;
+
+    model(this: GuidNode_niirdccoreRoute) {
+        return this.modelFor('guid-node');
+    }
+
+    @action
+    async didTransition() {
+        const { taskInstance } = this.controller.model as GuidRouteModel<Node>;
+        await taskInstance;
+        const node = taskInstance.value;
+
+        this.analytics.trackPage(node ? node.public : undefined, 'nodes');
+    }
+
+    // This tells ember-onbeforeunload's ConfirmationMixin whether or not to stop transitions
+    @computed('controller.isPageDirty')
+    get isPageDirty() {
+        const controller = this.controller as GuidNode_niirdccore;
+        return () => controller.isPageDirty;
+    }
+}

--- a/app/guid-node/niirdccore/styles.scss
+++ b/app/guid-node/niirdccore/styles.scss
@@ -1,0 +1,48 @@
+@media screen and (max-width: 768px) {
+    .DMPShow {
+        margin: 0;
+        padding: 0;
+    }
+}
+
+@media screen and (min-width: 769px) {
+    .DMPView {
+        margin-top: 15px;
+    }
+}
+
+.projectSummary {
+    font-size: 16px;
+
+    table {
+        tr {
+            border-top: solid;
+            border-bottom: solid;
+        }
+    }
+
+}
+
+table {
+    width: 90%;
+    margin: 1em;
+    font-size: 16px;
+    
+    th,
+    td {
+        padding: 0.5em;
+        
+    }
+    
+}
+
+th {
+    background: #efefef;
+    width: 25%;
+}
+
+.table {
+    th {
+        background: transparent;
+    }
+}

--- a/app/guid-node/niirdccore/template.hbs
+++ b/app/guid-node/niirdccore/template.hbs
@@ -15,7 +15,7 @@
 			<ul class="nav nav-stacked nav-pills">
 				<li><a href="#projectSummaryAnchor">プロジェクト概要</a></li>
 				<li><a href="#membersAnchor">メンバー</a></li>
-				<li><a href="#dataCollectMethodAnchor">研究データ<の収集・作成方法/a></li>
+				<li><a href="#dataCollectMethodAnchor">研究データの収集・作成方法</a></li>
 				<li><a href="#ethicsAnchor">研究倫理</a></li>
 				<li><a href="#dataSetAnchor">研究データセット</a></li>
 			</ul>

--- a/app/guid-node/niirdccore/template.hbs
+++ b/app/guid-node/niirdccore/template.hbs
@@ -1,0 +1,100 @@
+{{! using unsafeTitle here to avoid double encoding because the title helper does its own }}
+{{title ('ページタイトル' nodeTitle=this.model.taskInstance.value.unsafeTitle)}}
+
+<div class='container' local-class='DMPView'>
+    {{#if this.loading}}
+        loading
+    {{else}}
+    {{/if}}
+    
+	<span id="projectSummaryAnchor" class="anchor"></span>
+    <!-- Begin left column -->
+ 
+	<div class="col-sm-3 affix-parent scrollspy">
+		<div class="panel panel-default osf-affix" data-spy="affix" data-offset-top="0" data-offset-bottom="263"><!-- Begin sidebar -->
+			<ul class="nav nav-stacked nav-pills">
+				<li><a href="#projectSummaryAnchor">プロジェクト概要</a></li>
+				<li><a href="#membersAnchor">メンバー</a></li>
+				<li><a href="#dataCollectMethodAnchor">研究データ<の収集・作成方法/a></li>
+				<li><a href="#ethicsAnchor">研究倫理</a></li>
+				<li><a href="#dataSetAnchor">研究データセット</a></li>
+			</ul>
+		</div><!-- End sidebar -->
+	</div>
+
+    <!-- End left column -->
+
+	<div class="col-sm-9">
+		<div class="panel panel-default" id="projectSummary">
+			<div class="panel-heading clearfix">
+				<div class="row">
+					<div class="col-md-12">
+						<h3 class="panel-title">プロジェクト概要</h3>
+					</div>
+				</div>
+			</div>
+			<div class="panel-body projectSummary">
+				<table>
+					<tr>
+						<th>タイトル</th>
+						<td>{{title}}</td>
+					</tr>
+					<tr>
+						<th>説明</th>
+						<td>{{this.description}}</td>
+					</tr>
+				</table>
+			</div>  
+		</div>
+
+		<div class="panel panel-default" id="members">
+			<span id="membersAnchor" class="anchor"></span>
+			<div class="panel-heading clearfix">
+				<div class="row">
+					<div class="col-md-12">
+					<h3 class="panel-title">メンバー</h3>
+					</div>
+				</div>
+			</div>
+			<div class="panel-body">
+				<table class="table">
+					<thead>
+						<tr>
+							<th>氏名</th>
+							<th>メールアドレス</th>
+							<th>Project Role</th>
+							<th>ORCID</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>{{this.name}}</td>
+							<td>{{this.mbox}}</td>
+							<td>test</td>
+							<td>test</td>
+						</tr>
+					</tbody>
+				</table>
+				<h3>研究データ管理者</h3>
+				<table class="table">
+					<thead>
+						<tr>
+							<th>氏名</th>
+							<th>メールアドレス</th>
+							<th>Project Role</th>
+							<th>ORCID</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>{{this.name}}</td>
+							<td>{{this.mbox}}</td>
+							<td>test</td>
+							<td>test</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>  
+		</div>
+	</div>
+</div>

--- a/app/models/dmp-status.ts
+++ b/app/models/dmp-status.ts
@@ -1,0 +1,24 @@
+import DS from 'ember-data';
+import OsfModel from './osf-model';
+
+const { attr } = DS;
+
+export default class DMPStatusModel extends OsfModel {
+    @attr('string') dmp_id!: string;
+    @attr('string') contact!: string;
+    @attr('string') project!: string;
+    @attr('string') dataset!: string;
+    @attr('string') created!: string;
+    @attr('string') modified!: string;
+        
+//    @attr('string') name!: string;
+//    @attr('string') mbox!: string;
+//    @attr('string') title!: string;
+//    @attr('string') description!: string;
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        'dmp-status': DMPStatusModel;
+    } // eslint-disable-line semi
+}

--- a/app/models/dmp-status.ts
+++ b/app/models/dmp-status.ts
@@ -4,17 +4,11 @@ import OsfModel from './osf-model';
 const { attr } = DS;
 
 export default class DMPStatusModel extends OsfModel {
-    @attr('string') dmp_id!: string;
-    @attr('string') contact!: string;
-    @attr('string') project!: string;
-    @attr('string') dataset!: string;
-    @attr('string') created!: string;
-    @attr('string') modified!: string;
         
-//    @attr('string') name!: string;
-//    @attr('string') mbox!: string;
-//    @attr('string') title!: string;
-//    @attr('string') description!: string;
+    @attr('string') name!: string;
+    @attr('string') mbox!: string;
+    @attr('string') title!: string;
+    @attr('string') description!: string;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/router.ts
+++ b/app/router.ts
@@ -142,6 +142,7 @@ Router.map(function() {
         this.mount('analytics-page', { as: 'analytics' });
         this.route('forks');
         this.route('iqbrims');
+        this.route('niirdccore');
         this.route('registrations');
         this.route('drafts', { path: '/drafts/:draftId' }, function() {
             this.route('register');

--- a/app/serializers/dmp-status.ts
+++ b/app/serializers/dmp-status.ts
@@ -1,0 +1,10 @@
+import OsfSerializer from './osf-serializer';
+
+export default class DMPStatusSerializer extends OsfSerializer {
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        'dmp-status': DMPStatusSerializer;
+    } // eslint-disable-line semi
+}

--- a/lib/osf-components/addon/components/node-navbar/component.ts
+++ b/lib/osf-components/addon/components/node-navbar/component.ts
@@ -42,7 +42,7 @@ export default class NodeNavbar extends Component {
         if (!this.node) {
             return null;
         }
-        let node = this.node;
+        const { node } = this;
         return (async () => {
             const addons = await node.addons;
             if (!addons) {
@@ -50,6 +50,22 @@ export default class NodeNavbar extends Component {
             }
             const iqbrims = addons.filter(addon => addon.id === 'iqbrims');
             return iqbrims.length > 0;
+        })();
+    }
+
+    @computed('node.addons.[]')
+    get niirdccoreEnabled(): Promise<boolean> | null {
+        if (!this.node) {
+            return null;
+        }
+        const { node } = this;
+        return (async () => {
+            const addons = await node.addons;
+            if (!addons) {
+                return false;
+            }
+            const niirdccore = addons.filter(addon => addon.id === 'niirdccore');
+            return niirdccore.length > 0;
         })();
     }
 

--- a/lib/osf-components/addon/components/node-navbar/template.hbs
+++ b/lib/osf-components/addon/components/node-navbar/template.hbs
@@ -35,6 +35,9 @@
                         {{/node-navbar/link}}
                         {{node-navbar/link node=@node useLinkTo=false destination='files'}}
 
+                        {{#if this.niirdccoreEnabled }}
+                            {{node-navbar/link node=@node useLinkTo=false destination='niirdccore'}}
+                        {{/if}}
                         {{#if this.iqbrimsEnabled }}
                             {{node-navbar/link node=@node useLinkTo=false destination='iqbrims'}}
                         {{/if}}


### PR DESCRIPTION
## Purpose

#22470 (2). DMP閲覧画面の実装※表示内容はダミー

## Summary of Changes

app/adapters/dmp-status.ts
app/guid-node/niirdccore/controller.ts
app/guid-node/niirdccore/route.ts
app/guid-node/niirdccore/styles.scss
app/guid-node/niirdccore/template.hbs
app/models/dmp-status.ts
app/router.ts
app/serializers/dmp-status.ts
lib/osf-components/addon/components/node-navbar/component.ts
lib/osf-components/addon/components/node-navbar/template.hbs