### PR TITLE
#22470 DMP閲覧画面のレイアウト・データモデル修正、国際化一時対応

### DIFF
--- a/app/guid-node/niirdccore/controller.ts
+++ b/app/guid-node/niirdccore/controller.ts
@@ -53,31 +53,13 @@ export default class GuidNode_niirdccore extends Controller {
         this.toast.error(message);
     }
 
-    @computed('config.name')
-    get name2() {
-        if (!this.config || !this.config.get('isFulfilled')) {
-            return '';
-        }
-        const config = this.config.content as DMPStatusModel;
-        return config.name;
-    }
-
-    @computed('config.mbox')
-    get mbox() {
-        if (!this.config || !this.config.get('isFulfilled')) {
-            return '';
-        }
-        const config = this.config.content as DMPStatusModel;
-        return config.mbox;
-    }
-
     @computed('config.title')
     get title() {
         if (!this.config || !this.config.get('isFulfilled')) {
             return '';
         }
         const config = this.config.content as DMPStatusModel;
-        return config.title;
+        return config.dmp.project.title;
     }
 
     @computed('config.description')
@@ -86,7 +68,25 @@ export default class GuidNode_niirdccore extends Controller {
             return '';
         }
         const config = this.config.content as DMPStatusModel;
-        return config.description;
+        return config.dmp.project.description;
+    }
+
+    @computed('config.contributors')
+    get contributors(){
+        if (!this.config || !this.config.get('isFulfilled')) {
+            return undefined;
+        }
+        const config = this.config.content as DMPStatusModel;
+        return config.dmp.contributors;
+    }
+
+    @computed('config.contact')
+    get contact() {
+        if (!this.config || !this.config.get('isFulfilled')) {
+            return '';
+        }
+        const config = this.config.content as DMPStatusModel;
+        return config.dmp.contact;
     }
 
     @computed('node')

--- a/app/guid-node/niirdccore/styles.scss
+++ b/app/guid-node/niirdccore/styles.scss
@@ -11,38 +11,47 @@
     }
 }
 
-.projectSummary {
-    font-size: 16px;
-
-    table {
-        tr {
-            border-top: solid;
-            border-bottom: solid;
-        }
-    }
-
+.anchor {
+    margin-top: -100px;
+    padding-top: 100px;
+    display: block;
+    z-index: -1;
+    position: relative;
 }
 
-table {
-    width: 90%;
+.affix {
+    position: fixed;
+}
+
+.projectSummaryTable {
+    width: 95%;
     margin: 1em;
     font-size: 16px;
-    
-    th,
+    margin-bottom: 20px;
+
+    th {
+        background: #efefef;
+        width: 230px;
+        padding: 0.5em;
+        font-weight: normal;
+    }
+
+    tr {
+        border-top: 2px solid #ddd;
+        border-bottom: 2px solid #ddd;
+    }
+
     td {
         padding: 0.5em;
-        
     }
-    
 }
 
-th {
-    background: #efefef;
-    width: 25%;
+.peopleTable {
+    width: 95%;
+    max-width: 95%;
+    margin-bottom: 20px;
 }
 
-.table {
-    th {
-        background: transparent;
-    }
+.peopleTableHeadding {
+    font-weight: bold;
 }

--- a/app/guid-node/niirdccore/template.hbs
+++ b/app/guid-node/niirdccore/template.hbs
@@ -1,100 +1,182 @@
 {{! using unsafeTitle here to avoid double encoding because the title helper does its own }}
-{{title ('ページタイトル' nodeTitle=this.model.taskInstance.value.unsafeTitle)}}
-
+{{title (t 'niirdccore.page_title' nodeTitle=this.model.taskInstance.value.unsafeTitle)}}
 <div class='container' local-class='DMPView'>
-    {{#if this.loading}}
-        loading
-    {{else}}
-    {{/if}}
-    
-	<span id="projectSummaryAnchor" class="anchor"></span>
-    <!-- Begin left column -->
- 
-	<div class="col-sm-3 affix-parent scrollspy">
-		<div class="panel panel-default osf-affix" data-spy="affix" data-offset-top="0" data-offset-bottom="263"><!-- Begin sidebar -->
-			<ul class="nav nav-stacked nav-pills">
-				<li><a href="#projectSummaryAnchor">プロジェクト概要</a></li>
-				<li><a href="#membersAnchor">メンバー</a></li>
-				<li><a href="#dataCollectMethodAnchor">研究データの収集・作成方法</a></li>
-				<li><a href="#ethicsAnchor">研究倫理</a></li>
-				<li><a href="#dataSetAnchor">研究データセット</a></li>
-			</ul>
-		</div><!-- End sidebar -->
-	</div>
 
+    <!-- Begin left column -->
+	<div class="col-sm-3 col-xs-12">
+		<!-- Begin sidebar -->
+		<div class="panel panel-default" local-class="affix">
+			<ul class="side-menu nav nav-stacked nav-pills">
+				<li><a href="#projectSummaryAnchor">{{t 'niirdccore.dmp_project.heading'}}</a></li>
+				<li><a href="#peopleAnchor">{{t 'niirdccore.dmp_people.heading'}}</a></li>
+				<li><a href="#dataCollectMethodAnchor">{{t 'niirdccore.dmp_data_collection.heading'}}</a></li>
+				<li><a href="#ethicsAnchor">{{t 'niirdccore.dmp_ethics.heading'}}</a></li>
+				<li><a href="#dataSetAnchor">{{t 'niirdccore.dmp_data_record.heading'}}</a></li>
+			</ul>
+		</div>
+		<!-- End sidebar -->
+	</div>
     <!-- End left column -->
 
+	<!-- Begin right column -->
 	<div class="col-sm-9">
+		<!-- Begin projectSummary -->
 		<div class="panel panel-default" id="projectSummary">
+			<span id="projectSummaryAnchor" local-class="anchor" class="tableAnchor"></span>
 			<div class="panel-heading clearfix">
 				<div class="row">
 					<div class="col-md-12">
-						<h3 class="panel-title">プロジェクト概要</h3>
-					</div>
-				</div>
-			</div>
-			<div class="panel-body projectSummary">
-				<table>
-					<tr>
-						<th>タイトル</th>
-						<td>{{title}}</td>
-					</tr>
-					<tr>
-						<th>説明</th>
-						<td>{{this.description}}</td>
-					</tr>
-				</table>
-			</div>  
-		</div>
-
-		<div class="panel panel-default" id="members">
-			<span id="membersAnchor" class="anchor"></span>
-			<div class="panel-heading clearfix">
-				<div class="row">
-					<div class="col-md-12">
-					<h3 class="panel-title">メンバー</h3>
+						<h3 class="panel-title">{{t 'niirdccore.dmp_project.heading'}}</h3>
 					</div>
 				</div>
 			</div>
 			<div class="panel-body">
-				<table class="table">
-					<thead>
-						<tr>
-							<th>氏名</th>
-							<th>メールアドレス</th>
-							<th>Project Role</th>
-							<th>ORCID</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td>{{this.name}}</td>
-							<td>{{this.mbox}}</td>
-							<td>test</td>
-							<td>test</td>
-						</tr>
-					</tbody>
-				</table>
-				<h3>研究データ管理者</h3>
-				<table class="table">
-					<thead>
-						<tr>
-							<th>氏名</th>
-							<th>メールアドレス</th>
-							<th>Project Role</th>
-							<th>ORCID</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td>{{this.name}}</td>
-							<td>{{this.mbox}}</td>
-							<td>test</td>
-							<td>test</td>
-						</tr>
-					</tbody>
+				<table class="table" local-class="projectSummaryTable">
+					<tr>
+						<th>{{t 'niirdccore.dmp_project.title'}}</th>
+						<td>{{this.title}}</td>
+					</tr>
+					<tr>
+						<th>{{t 'niirdccore.dmp_project.description'}}</th>
+						<td>{{this.description}}</td>
+					</tr>
+					<tr>
+						<th>{{t 'niirdccore.dmp_project.id'}}</th>
+						<td>{{this.projectID}}</td>
+					</tr>
+					<tr>
+						<th>{{t 'niirdccore.dmp_project.final_keywords'}}</th>
+						<td>{{this.keyword}}</td>
+					</tr>
+					<tr>
+						<th>{{t 'niirdccore.dmp_project.website'}}</th>
+						<td>{{this.projectWebSite}}</td>
+					</tr>
+					<tr>
+						<th>{{t 'niirdccore.dmp_project.start_day'}}</th>
+						<td>{{this.projectStartDay}}</td>
+					</tr>
+					<tr>
+						<th>{{t 'niirdccore.dmp_project.end_day'}}</th>
+						<td>{{this.projectEndDay}}</td>
+					</tr>
+					<tr>
+						<th>{{t 'niirdccore.dmp_project.foaf_fundedby_vivo_grant'}}</th>
+						<td>{{this.researchFundingSource}}</td>
+					</tr>
+					<tr>
+						<th>{{t 'niirdccore.dmp_project.foaf_fundedby_foaf_agent'}}</th>
+						<td>{{this.researchGrantNumber}}</td>
+					</tr>
+					<tr>
+						<th>{{t 'niirdccore.dmp_project.activity_type'}}</th>
+						<td>{{this.researchActivityType}}</td>
+					</tr>
 				</table>
 			</div>  
 		</div>
+		<!-- end projectSummary -->
+		<!-- Begin member -->
+		<div class="panel panel-default">
+			<span id="peopleAnchor" local-class="anchor" class="tableAnchor"></span>
+			<div class="panel-heading clearfix">
+				<div class="row">
+					<div class="col-md-12">
+						<h3 class="panel-title">{{t 'niirdccore.dmp_people.heading'}}</h3>
+					</div>
+				</div>
+			</div>
+
+			<div class="panel-body">
+				<table class="table" local-class="peopleTable">
+					<thead>
+						<tr>
+							<th>{{t 'niirdccore.dmp_people.name'}}</th>
+							<th>{{t 'niirdccore.dmp_people.email_hdr'}}</th>
+							<th>{{t 'niirdccore.dmp_people.project_role'}}</th>
+							<th>{{t 'niirdccore.dmp_people.orcid_hdr'}}</th>
+						</tr>
+					</thead>
+					<tbody>
+						{{#each this.contributors as | item | }}
+						<tr>
+							<td>{{item.name}}</td>
+							<td>{{item.mbox}}</td>
+							<td>{{item.role}}</td>
+							<td>{{item.orcid}}</td>
+						</tr>
+						{{/each}}
+					</tbody>
+				</table>
+				<h5 local-class="peopleTableHeadding">{{t 'niirdccore.dmp_people.data_manager'}}</h5>
+				<table class="table" local-class="peopleTable">
+					<thead>
+						<tr>
+							<th>{{t 'niirdccore.dmp_people.name'}}</th>
+							<th>{{t 'niirdccore.dmp_people.email_hdr'}}</th>
+							<th>{{t 'niirdccore.dmp_people.project_role'}}</th>
+							<th>{{t 'niirdccore.dmp_people.orcid_hdr'}}</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>{{this.contact.name}}</td>
+							<td>{{this.contact.mbox}}</td>
+							<td>{{this.contact.role}}</td>
+							<td>{{this.contact.orcid}}</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+		<!-- end member -->
 	</div>
+	<!-- End right column -->
 </div>
+
+<script>
+	// Activate the menu depending on the position of the content
+	$(function(){
+		var timeoutId;
+		var elementTop = new Array;
+		var current = -1;
+
+		// Store the anchor position in the elementTop array
+		$(".tableAnchor").each(function(i){
+			elementTop[i] = $(this).offset().top;
+		});
+
+		// Set the initial display
+		changeBackColor(0);
+
+		// Scroll event
+		$(window).scroll(function(){
+
+			// Skip if Timeout
+			if(timeoutId) return;
+
+			// Perform every 500ms (To improve performance)
+			timeoutId = setTimeout(function(){
+				timeoutId = 0;
+
+				var currentPosition = $(window).scrollTop();
+				for (var i = elementTop.length - 1 ; i >= 0; i--) {
+					if (currentPosition > elementTop[i]) {
+						changeBackColor(i);
+						break;
+					}
+				}
+			}, 500);
+		});
+
+		// Side menu background color setting
+		function changeBackColor(secNum) {
+			if(secNum != current) {
+				current = secNum;
+				secNum2 = secNum + 1; // For HTML order
+				$('.side-menu li').removeClass('active');
+				$('.side-menu li:nth-child(' + secNum2 + ')').addClass('active');
+			}
+		}
+	});
+</script>

--- a/app/models/dmp-status.ts
+++ b/app/models/dmp-status.ts
@@ -3,12 +3,26 @@ import OsfModel from './osf-model';
 
 const { attr } = DS;
 
+export interface MemberModel {
+    mbox: string;
+    name: string;
+    role: string;
+    orcid: string;
+}
+
+export interface ProjectModel {
+    title: string;
+    description: string;
+}
+
+export interface DMPModel {
+    project: ProjectModel;
+    contact: MemberModel;
+    contributors: MemberModel;
+}
+
 export default class DMPStatusModel extends OsfModel {
-        
-    @attr('string') name!: string;
-    @attr('string') mbox!: string;
-    @attr('string') title!: string;
-    @attr('string') description!: string;
+    @attr() dmp!: DMPModel;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -238,7 +238,7 @@ new_project:
     storage_region: 'Storage location'
     could_not_create_project: 'Could not create project'
     creating: 'Saving your project...'
-    create_failed_header: 'Couldn\'t create your project'
+    create_failed_header: 'Couldn''t create your project'
     create_failed_msg: 'There was an unknown error. Please try again later.'
 banners:
     prereg:
@@ -542,6 +542,7 @@ node_navbar:
     toggle: 'Toggle navigation'
     project_nav: 'Project Navigation'
     iqbrims: 'IQB-RIMS'
+    niirdccore: 'NII RDC Core'
     wiki: Wiki
     analytics: Analytics
     registrations: Registrations
@@ -1680,7 +1681,7 @@ dev_tools:
         toast_events: 'Display toast for tracked events'
         show_url_bar: 'Show URL bar -- navigate by URL without reloading'
 iqbrims:
-    page_title: '{{nodeTitle}} IQB-RIMS'
+    page_title: '{nodeTitle} IQB-RIMS'
     header_overview: 'Overview of Paper'
     header_manuscripts: 'Final Manuscript/Composition'
     header_data: 'Raw Data'
@@ -1742,3 +1743,33 @@ iqbrims:
     has_checklist: 'チェックリスト'
     files_comment: 'コメント'
     uploader_comment: 'コメント'
+
+niirdccore:
+    page_title: '{nodeTitle} NII RDC Core'
+    header: 'NII RDC Core'
+    loading: 'Loading DMP data...'
+    dmp_project:
+        heading: 'プロジェクト概要'
+        title: 'タイトル'
+        description: '説明'
+        id: 'プロジェクトID'
+        final_keywords: 'キーワード'
+        website: 'プロジェクトのウェブサイト'
+        start_day: 'プロジェクト開始日'
+        end_day: 'プロジェクト終了日'
+        foaf_fundedby_vivo_grant: '研究費助成元'
+        foaf_fundedby_foaf_agent: '研究費助成番号'
+        activity_type: '研究活動の種別'
+    dmp_people:
+        heading: 'メンバー'
+        name: '氏名'
+        data_manager: '研究データ管理者'
+        email_hdr: 'メールアドレス'
+        project_role: 'Project Role'
+        orcid_hdr: 'ORCID'
+    dmp_data_collection:
+        heading: '研究データの収集・作成方法'
+    dmp_ethics:
+        heading: '研究倫理'
+    dmp_data_record:
+        heading: '研究データセット'


### PR DESCRIPTION
## Purpose

#22470 3.(4).(2). DMP閲覧画面の実装
・DMP閲覧画面のレイアウトを修正
・DMP閲覧画面に表示するデータモデル（dmp-status）をDMPデータに合わせて階層化
・国際化一時対応（ビルドエラーが発生したため、コアアドオン以外の部分も修正）

## Summary of Changes

app/guid-node/niirdccore/controller.ts
app/guid-node/niirdccore/styles.scss
app/guid-node/niirdccore/template.hbs
app/models/dmp-status.ts
translations/en-us.yml
