### PR TITLE
#22470 DMP閲覧画面にDMP情報取得APIのスキーマ拡張を反映

### DIFF
--- a/app/guid-node/niirdccore/controller.ts
+++ b/app/guid-node/niirdccore/controller.ts
@@ -53,22 +53,13 @@ export default class GuidNode_niirdccore extends Controller {
         this.toast.error(message);
     }
 
-    @computed('config.title')
-    get title() {
+    @computed('config.project')
+    get project() {
         if (!this.config || !this.config.get('isFulfilled')) {
             return '';
         }
         const config = this.config.content as DMPStatusModel;
-        return config.dmp.project.title;
-    }
-
-    @computed('config.description')
-    get description() {
-        if (!this.config || !this.config.get('isFulfilled')) {
-            return '';
-        }
-        const config = this.config.content as DMPStatusModel;
-        return config.dmp.project.description;
+        return config.dmp.project;
     }
 
     @computed('config.contributors')

--- a/app/guid-node/niirdccore/template.hbs
+++ b/app/guid-node/niirdccore/template.hbs
@@ -30,50 +30,55 @@
 					</div>
 				</div>
 			</div>
+			{{#if this.loading}}
+				<LoadingIndicator  @dark={{true}} />
+			{{else}}
 			<div class="panel-body">
-				<table class="table" local-class="projectSummaryTable">
-					<tr>
-						<th>{{t 'niirdccore.dmp_project.title'}}</th>
-						<td>{{this.title}}</td>
-					</tr>
-					<tr>
-						<th>{{t 'niirdccore.dmp_project.description'}}</th>
-						<td>{{this.description}}</td>
-					</tr>
-					<tr>
-						<th>{{t 'niirdccore.dmp_project.id'}}</th>
-						<td>{{this.projectID}}</td>
-					</tr>
-					<tr>
-						<th>{{t 'niirdccore.dmp_project.final_keywords'}}</th>
-						<td>{{this.keyword}}</td>
-					</tr>
-					<tr>
-						<th>{{t 'niirdccore.dmp_project.website'}}</th>
-						<td>{{this.projectWebSite}}</td>
-					</tr>
-					<tr>
-						<th>{{t 'niirdccore.dmp_project.start_day'}}</th>
-						<td>{{this.projectStartDay}}</td>
-					</tr>
-					<tr>
-						<th>{{t 'niirdccore.dmp_project.end_day'}}</th>
-						<td>{{this.projectEndDay}}</td>
-					</tr>
-					<tr>
-						<th>{{t 'niirdccore.dmp_project.foaf_fundedby_vivo_grant'}}</th>
-						<td>{{this.researchFundingSource}}</td>
-					</tr>
-					<tr>
-						<th>{{t 'niirdccore.dmp_project.foaf_fundedby_foaf_agent'}}</th>
-						<td>{{this.researchGrantNumber}}</td>
-					</tr>
-					<tr>
-						<th>{{t 'niirdccore.dmp_project.activity_type'}}</th>
-						<td>{{this.researchActivityType}}</td>
-					</tr>
-				</table>
-			</div>  
+
+					<table class="table" local-class="projectSummaryTable">
+						<tr>
+							<th>{{t 'niirdccore.dmp_project.title'}}</th>
+							<td>{{this.project.title}}</td>
+						</tr>
+						<tr>
+							<th>{{t 'niirdccore.dmp_project.description'}}</th>
+							<td>{{this.project.description}}</td>
+						</tr>
+						<tr>
+							<th>{{t 'niirdccore.dmp_project.id'}}</th>
+							<td>{{this.project.project_id}}</td>
+						</tr>
+						<tr>
+							<th>{{t 'niirdccore.dmp_project.final_keywords'}}</th>
+							<td>{{this.project.keywords}}</td>
+						</tr>
+						<tr>
+							<th>{{t 'niirdccore.dmp_project.website'}}</th>
+							<td>{{this.project.website}}</td>
+						</tr>
+						<tr>
+							<th>{{t 'niirdccore.dmp_project.start_day'}}</th>
+							<td>{{this.project.start}}</td>
+						</tr>
+						<tr>
+							<th>{{t 'niirdccore.dmp_project.end_day'}}</th>
+							<td>{{this.project.end}}</td>
+						</tr>
+						<tr>
+							<th>{{t 'niirdccore.dmp_project.foaf_fundedby_vivo_grant'}}</th>
+							<td>{{this.project.funding.funder_name}}</td>
+						</tr>
+						<tr>
+							<th>{{t 'niirdccore.dmp_project.foaf_fundedby_foaf_agent'}}</th>
+							<td>{{this.project.funding.grand_id.identifier}}</td>
+						</tr>
+						<tr>
+							<th>{{t 'niirdccore.dmp_project.activity_type'}}</th>
+							<td>{{this.project.type}}</td>
+						</tr>
+					</table>
+				</div>
+			{{/if}}
 		</div>
 		<!-- end projectSummary -->
 		<!-- Begin member -->
@@ -87,47 +92,59 @@
 				</div>
 			</div>
 
-			<div class="panel-body">
-				<table class="table" local-class="peopleTable">
-					<thead>
-						<tr>
-							<th>{{t 'niirdccore.dmp_people.name'}}</th>
-							<th>{{t 'niirdccore.dmp_people.email_hdr'}}</th>
-							<th>{{t 'niirdccore.dmp_people.project_role'}}</th>
-							<th>{{t 'niirdccore.dmp_people.orcid_hdr'}}</th>
-						</tr>
-					</thead>
-					<tbody>
-						{{#each this.contributors as | item | }}
-						<tr>
-							<td>{{item.name}}</td>
-							<td>{{item.mbox}}</td>
-							<td>{{item.role}}</td>
-							<td>{{item.orcid}}</td>
-						</tr>
-						{{/each}}
-					</tbody>
-				</table>
-				<h5 local-class="peopleTableHeadding">{{t 'niirdccore.dmp_people.data_manager'}}</h5>
-				<table class="table" local-class="peopleTable">
-					<thead>
-						<tr>
-							<th>{{t 'niirdccore.dmp_people.name'}}</th>
-							<th>{{t 'niirdccore.dmp_people.email_hdr'}}</th>
-							<th>{{t 'niirdccore.dmp_people.project_role'}}</th>
-							<th>{{t 'niirdccore.dmp_people.orcid_hdr'}}</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td>{{this.contact.name}}</td>
-							<td>{{this.contact.mbox}}</td>
-							<td>{{this.contact.role}}</td>
-							<td>{{this.contact.orcid}}</td>
-						</tr>
-					</tbody>
-				</table>
-			</div>
+			{{#if this.loading}}
+				<LoadingIndicator @dark={{true}} />
+			{{else}}
+				<div class="panel-body">
+					<table class="table" local-class="peopleTable">
+						<thead>
+							<tr>
+								<th>{{t 'niirdccore.dmp_people.name'}}</th>
+								<th>{{t 'niirdccore.dmp_people.email_hdr'}}</th>
+								<th>{{t 'niirdccore.dmp_people.project_role'}}</th>
+								<th>{{t 'niirdccore.dmp_people.orcid_hdr'}}</th>
+							</tr>
+						</thead>
+						<tbody>
+							{{#each this.contributors as | item | }}
+							<tr>
+								<td>{{item.name}}</td>
+								<td>{{item.mbox}}</td>
+								<td>{{item.role}}</td>
+								<td>
+									{{#if (eq item.contact_id.type "orcid")}}
+										{{item.contact_id.identifier}}
+									{{/if}}
+								</td>
+							</tr>
+							{{/each}}
+						</tbody>
+					</table>
+					<h5 local-class="peopleTableHeadding">{{t 'niirdccore.dmp_people.data_manager'}}</h5>
+					<table class="table" local-class="peopleTable">
+						<thead>
+							<tr>
+								<th>{{t 'niirdccore.dmp_people.name'}}</th>
+								<th>{{t 'niirdccore.dmp_people.email_hdr'}}</th>
+								<th>{{t 'niirdccore.dmp_people.project_role'}}</th>
+								<th>{{t 'niirdccore.dmp_people.orcid_hdr'}}</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td>{{this.contact.name}}</td>
+								<td>{{this.contact.mbox}}</td>
+								<td>{{this.contact.role}}</td>
+								<td>
+									{{#if (eq this.contact.contact_id.type "orcid")}}
+										{{this.contact.contact_id.identifier}}
+									{{/if}}
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			{{/if}}
 		</div>
 		<!-- end member -->
 	</div>

--- a/app/models/dmp-status.ts
+++ b/app/models/dmp-status.ts
@@ -3,16 +3,32 @@ import OsfModel from './osf-model';
 
 const { attr } = DS;
 
+export interface IdentiferModel {
+    identifier: string;
+    type: string;
+}
 export interface MemberModel {
+    contact_id: IdentiferModel;
     mbox: string;
     name: string;
     role: string;
-    orcid: string;
+}
+
+export interface FundingModel{
+    funder_name: string;
+    grand_id: IdentiferModel;
 }
 
 export interface ProjectModel {
     title: string;
     description: string;
+    project_id: string;
+    keywords: string;
+    website: string;
+    start: Date;
+    end: Date;
+    funding: FundingModel;
+    type: string;
 }
 
 export interface DMPModel {


### PR DESCRIPTION
## Purpose

#22470 3.(4).(2). DMP閲覧画面にDMP情報取得APIのスキーマ拡張を反映
・DMP情報取得APIのスキーマ拡張を反映
・controllerのgetメソッドを、クラス単位で返却するように修正
・データロード中は各table部分にLoadingIndicatorを表示するように修正

## Summary of Changes

app/guid-node/niirdccore/controller.ts
app/guid-node/niirdccore/template.hbs
app/models/dmp-status.ts