### PR TITLE
BinderHubアドオン repo2docker対応

### DIFF
--- a/app/guid-node/binderhub/-components/build-console/component.ts
+++ b/app/guid-node/binderhub/-components/build-console/component.ts
@@ -88,9 +88,10 @@ export default class BuildConsole extends Component {
     scrollToBottom() {
         const terminal = $('#binderhub-build-terminal');
         const terminalContent = $('#binderhub-build-terminal pre');
-        console.log('scrollToBottom', terminalContent.height());
-        terminal.delay(10).animate({
-            scrollTop: terminalContent.height(),
-        }, 500);
+        const height = terminalContent.height();
+        if (!height) {
+            return;
+        }
+        terminal.scrollTop(height);
     }
 }

--- a/app/guid-node/binderhub/-components/build-console/component.ts
+++ b/app/guid-node/binderhub/-components/build-console/component.ts
@@ -87,8 +87,10 @@ export default class BuildConsole extends Component {
 
     scrollToBottom() {
         const terminal = $('#binderhub-build-terminal');
+        const terminalContent = $('#binderhub-build-terminal pre');
+        console.log('scrollToBottom', terminalContent.height());
         terminal.delay(10).animate({
-            scrollTop: terminal.height(),
+            scrollTop: terminalContent.height(),
         }, 500);
     }
 }

--- a/app/guid-node/binderhub/-components/project-editor/component.ts
+++ b/app/guid-node/binderhub/-components/project-editor/component.ts
@@ -315,7 +315,7 @@ export default class ProjectEditor extends Component {
         if (superuser) {
             content += 'USER $NB_USER\n';
         }
-        content += 'COPY * .\n';
+        content += 'COPY * ./\n';
         const checksum = md5(content.trim());
         return `# rdm-binderhub:hash:${checksum}\n${content}`;
     }

--- a/app/guid-node/binderhub/-components/project-editor/component.ts
+++ b/app/guid-node/binderhub/-components/project-editor/component.ts
@@ -314,7 +314,7 @@ export default class ProjectEditor extends Component {
             condaPackages = condaPackages.concat(imageURL.params.map(pkg => getCondaPackageId(pkg)));
         }
         let content = `name: "${imageURL.fullurl}"\n`;
-        if (condaPackages.length > 0 && this.condaSupported) {
+        if (condaPackages.length > 0) {
             content += 'dependencies:\n';
             content += condaPackages.map(item => `- ${item}\n`).join('');
         }

--- a/app/guid-node/binderhub/-components/project-editor/styles.scss
+++ b/app/guid-node/binderhub/-components/project-editor/styles.scss
@@ -25,3 +25,8 @@
 .postscript_view button {
     margin-left: auto;
 }
+
+.environment_setting_error {
+    font-weight: bold;
+    color: #f00;
+}

--- a/app/guid-node/binderhub/-components/project-editor/template.hbs
+++ b/app/guid-node/binderhub/-components/project-editor/template.hbs
@@ -109,6 +109,20 @@
                             @onUpdate={{action this.rGitHubUpdated}}
                         />
                     {{/if}}
+                    {{#if this.rMranSupported}}
+                        <GuidNode::Binderhub::-Components::PackageEditor
+                            data-test-package-editor='rmran'
+                            @node={{this.node}}
+                            @label='R (MRAN)'
+                            @packages={{this.rMranPackages}}
+                            @onUpdate={{action this.rMranUpdated}}
+                        />
+                        {{#if this.mranVersionSettingError}}
+                            <div local-class='environment_setting_error'>
+                                {{t 'binderhub.deployment.mran_version_setting_error'}}
+                            </div>
+                        {{/if}}
+                    {{/if}}
                 </div>
                 <h3>{{t 'binderhub.deployment.postinstallscript'}}</h3>
                 <div local-class='postscript_view'>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1778,6 +1778,7 @@ binderhub:
         open_node_files: 'Open Files'
         refresh_post_install: 'Refresh'
         refreshing_post_install: 'Refreshing...'
+        mran_version_setting_error: 'The version number cannot be specified for MRAN.'
         placeholders:
             package_name: 'Name'
             package_version: 'Version'

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -1777,6 +1777,7 @@ binderhub:
         open_node_files: 'ファイル一覧を開く'
         refresh_post_install: '更新'
         refreshing_post_install: '更新中...'
+        mran_version_setting_error: 'MRANにバージョン番号を指定することはできません。'
         placeholders:
             package_name: '名前'
             package_version: 'バージョン'


### PR DESCRIPTION
- Ticket: GRDM-23355, GRDM-27082
- Feature flag: n/a

## Purpose

- BinderHubアドオンでrepo2dockerのProfileを指定できるように変更。

## Summary of Changes

- GRDM-23355: BinderHubアドオンをrepo2dockerベースの環境設定に対応
  - BinderHubの  `BINDERHUB_DEPLOYMENT_IMAGES` の `url` に `#repo2docker#r-base` などと `#repo2docker#パッケージ名,...` と指定すると、パッケージ名で指定されたdependenciesを持つ`environment.yml`を生成するように機能追加
  - `install.R`の編集用に R(MRAN)パッケージ種別を追加
- GRDM-27082: Dockerfile内のパスを修正

## Side Effects

None

## QA Notes

None