### PR TITLE
Fix iqbrims and binderhub tabs

### DIFF
--- a/lib/osf-components/addon/components/node-navbar/component.ts
+++ b/lib/osf-components/addon/components/node-navbar/component.ts
@@ -4,6 +4,7 @@ import config from 'ember-get-config';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import Node from 'ember-osf-web/models/node';
+import NodeAddonModel from 'ember-osf-web/models/node-addon';
 
 import styles from './styles';
 import template from './template';
@@ -37,40 +38,52 @@ export default class NodeNavbar extends Component {
         return null;
     }
 
-    @computed('node.addons.[]')
-    get iqbrimsEnabled(): Promise<boolean> | null {
+    @computed('node.addons')
+    get iqbrimsEnabled(): boolean | null {
         if (!this.node) {
             return null;
         }
-        const { node } = this;
-        return (async () => {
-            const addons = await node.addons;
-            if (!addons) {
-                return false;
-            }
-            const iqbrims = addons.filter(addon => addon.id === 'iqbrims' && addon.configured);
-            return iqbrims.length > 0;
-        })();
+        let result = null;
+        this.getAddons()
+            .then(addons => {
+                result = addons
+                    .filter(addon => addon.id === 'iqbrims' && addon.configured)
+                    .length > 0;
+                this.set('iqbrimsEnabled', result);
+            });
+        return result;
     }
 
-    @computed('node.addons.[]')
-    get binderhubEnabled(): Promise<boolean> | null {
+    @computed('node.addons')
+    get binderhubEnabled(): boolean | null {
         if (!this.node) {
             return null;
         }
-        const { node } = this;
-        return (async () => {
-            const addons = await node.addons;
-            if (!addons) {
-                return false;
-            }
-            const binderhub = addons.filter(addon => addon.id === 'binderhub' && addon.configured);
-            return binderhub.length > 0;
-        })();
+        let result = null;
+        this.getAddons()
+            .then(addons => {
+                result = addons
+                    .filter(addon => addon.id === 'binderhub' && addon.configured)
+                    .length > 0;
+                this.set('binderhubEnabled', result);
+            });
+        return result;
     }
 
     @action
     toggleNav() {
         this.toggleProperty('collapsedNav');
+    }
+
+    async getAddons(): Promise<NodeAddonModel[]> {
+        const { node } = this;
+        if (!node) {
+            return [];
+        }
+        const addons = await node.addons;
+        if (!addons) {
+            return [];
+        }
+        return addons.map(addon => addon);
     }
 }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: GRDM-27224
- Feature flag: n/a

## Purpose

* ember-osf-webで作られたプロジェクト画面を参照する際に、常にIQB-RIMSアドオンとBinderHubアドオンタブが表示されてしまう(クリックしても内容を参照することはできない)バグの修正

## Summary of Changes

* Promise<boolean>がTemplateで意図した解釈をされていなかったので、booleanを返すように修正
* addonsの読み込みが遅延して実施された際のため、 `this.set('プロパティ名', true|false)` を明示的に行うように修正

## Side Effects

None

## QA Notes

None