### PR TITLE
[GRDM-29660] Fix IQB-RIMS and other tabs

### DIFF
--- a/lib/osf-components/addon/components/node-navbar/component.ts
+++ b/lib/osf-components/addon/components/node-navbar/component.ts
@@ -47,7 +47,7 @@ export default class NodeNavbar extends Component {
         this.getAddons()
             .then(addons => {
                 result = addons
-                    .filter(addon => addon.id === 'iqbrims' && addon.configured)
+                    .filter(addon => addon.id === 'iqbrims')
                     .length > 0;
                 this.set('iqbrimsEnabled', result);
             });

--- a/lib/osf-components/addon/components/node-navbar/template.hbs
+++ b/lib/osf-components/addon/components/node-navbar/template.hbs
@@ -44,12 +44,6 @@
                         {{#if this.binderhubEnabled }}
                             {{node-navbar/link node=@node useLinkTo=false destination='binderhub'}}
                         {{/if}}
-                        {{#if (or @node.public @node.currentUserIsContributor)}}
-                            {{node-navbar/link node=@node useLinkTo=true destination='analytics'}}
-                        {{/if}}
-                        {{#unless @node.isRegistration}}
-                            {{node-navbar/link node=@node useLinkTo=true destination='registrations'}}
-                        {{/unless}}
                         {{#if @node.currentUserIsContributor}}
                             {{node-navbar/link node=@node useLinkTo=false destination='contributors'}}
                         {{/if}}

--- a/lib/osf-components/addon/components/node-navbar/template.hbs
+++ b/lib/osf-components/addon/components/node-navbar/template.hbs
@@ -38,11 +38,11 @@
                         {{#if this.iqbrimsEnabled }}
                             {{node-navbar/link node=@node useLinkTo=false destination='iqbrims'}}
                         {{/if}}
-                        {{#if this.binderhubEnabled }}
-                            {{node-navbar/link node=@node useLinkTo=false destination='binderhub'}}
-                        {{/if}}
                         {{#if @node.wikiEnabled}}
                             {{node-navbar/link node=@node useLinkTo=false destination='wiki'}}
+                        {{/if}}
+                        {{#if this.binderhubEnabled }}
+                            {{node-navbar/link node=@node useLinkTo=false destination='binderhub'}}
                         {{/if}}
                         {{#if (or @node.public @node.currentUserIsContributor)}}
                             {{node-navbar/link node=@node useLinkTo=true destination='analytics'}}

--- a/tests/integration/components/node-navbar/component-test.ts
+++ b/tests/integration/components/node-navbar/component-test.ts
@@ -121,7 +121,6 @@ module('Integration | Component | node-navbar', () => {
                 links: [
                     NavLink.ThisNode,
                     NavLink.Files,
-                    NavLink.Registrations,
                 ],
             },
             {
@@ -137,7 +136,6 @@ module('Integration | Component | node-navbar', () => {
                     NavLink.ParentNode,
                     NavLink.ThisNode,
                     NavLink.Files,
-                    NavLink.Registrations,
                 ],
             },
             {
@@ -145,8 +143,6 @@ module('Integration | Component | node-navbar', () => {
                 links: [
                     NavLink.ThisNode,
                     NavLink.Files,
-                    NavLink.Analytics,
-                    NavLink.Registrations,
                 ],
             },
             {
@@ -158,8 +154,6 @@ module('Integration | Component | node-navbar', () => {
                     NavLink.ParentNode,
                     NavLink.ThisNode,
                     NavLink.Files,
-                    NavLink.Analytics,
-                    NavLink.Registrations,
                 ],
             },
             {
@@ -171,8 +165,6 @@ module('Integration | Component | node-navbar', () => {
                 links: [
                     NavLink.ThisNode,
                     NavLink.Files,
-                    NavLink.Analytics,
-                    NavLink.Registrations,
                     NavLink.Contributors,
                     NavLink.Addons,
                     NavLink.Settings,
@@ -186,8 +178,6 @@ module('Integration | Component | node-navbar', () => {
                 links: [
                     NavLink.ThisNode,
                     NavLink.Files,
-                    NavLink.Analytics,
-                    NavLink.Registrations,
                     NavLink.Contributors,
                     NavLink.Settings,
                 ],
@@ -205,8 +195,6 @@ module('Integration | Component | node-navbar', () => {
                     NavLink.ThisNode,
                     NavLink.Files,
                     NavLink.Wiki,
-                    NavLink.Analytics,
-                    NavLink.Registrations,
                     NavLink.Contributors,
                     NavLink.Addons,
                     NavLink.Settings,
@@ -223,7 +211,6 @@ module('Integration | Component | node-navbar', () => {
                     NavLink.ThisNode,
                     NavLink.Files,
                     NavLink.Wiki,
-                    NavLink.Analytics,
                     NavLink.Contributors,
                 ],
             },
@@ -239,7 +226,6 @@ module('Integration | Component | node-navbar', () => {
                     NavLink.ThisNode,
                     NavLink.Files,
                     NavLink.Wiki,
-                    NavLink.Analytics,
                     NavLink.Contributors,
                     NavLink.Settings,
                 ],
@@ -255,7 +241,6 @@ module('Integration | Component | node-navbar', () => {
                     NavLink.ThisNode,
                     NavLink.Files,
                     NavLink.Wiki,
-                    NavLink.Registrations,
                     NavLink.Settings,
                 ],
             },
@@ -271,7 +256,6 @@ module('Integration | Component | node-navbar', () => {
                     NavLink.ThisNode,
                     NavLink.Files,
                     NavLink.Wiki,
-                    NavLink.Analytics,
                 ],
             },
             {
@@ -282,7 +266,6 @@ module('Integration | Component | node-navbar', () => {
                     NavLink.ThisNode,
                     NavLink.Files,
                     NavLink.IQBRIMS,
-                    NavLink.Registrations,
                 ],
             },
             {
@@ -293,7 +276,6 @@ module('Integration | Component | node-navbar', () => {
                     NavLink.ThisNode,
                     NavLink.Files,
                     NavLink.BinderHub,
-                    NavLink.Registrations,
                 ],
             },
         ];


### PR DESCRIPTION
- Ticket: GRDM-29660
- Feature flag: n/a

## Purpose

IQB-RIMS他タブの挙動修正

## Summary of Changes

- IQB-RIMSタブの表示についてはRDM-osf.ioと同様にIQB-RIMSアドオンがEnabledであれば(Driveの紐付けがなされていなくても)表示する
- 「分析」「登録」のタブを非表示にする

## Side Effects

None

## QA Notes

None
