### PR TITLE
[GRDM-31485,GRDM-31190,GRDM-31645] メタデータ, BinderHubアドオンの修正

### DIFF
--- a/app/guid-node/binderhub/-components/project-editor/component.ts
+++ b/app/guid-node/binderhub/-components/project-editor/component.ts
@@ -341,7 +341,7 @@ export default class ProjectEditor extends Component {
             content += 'RUN /postBuild\n';
             content += '\n';
         }
-        content += 'COPY * ./\n';
+        content += 'COPY . .\n';
         const checksum = md5(content.trim());
         return `# rdm-binderhub:hash:${checksum}\n${content}`;
     }

--- a/app/guid-node/metadata/controller.ts
+++ b/app/guid-node/metadata/controller.ts
@@ -52,11 +52,10 @@ export default class GuidNodeMetadata extends Controller {
         const schemas = allSchemas.filter((a: RegistrationSchema) => checkGRDMSchema(a));
         schemas.sort((a: RegistrationSchema, b: RegistrationSchema) => a.name.length - b.name.length);
 
-        if (this.node) {
-            const metadataSchema: MetadataNodeSchemaModel = yield this.store
-                .findRecord('metadata-node-schema', this.node.id);
-            this.set('metadataSchema', metadataSchema);
-        }
+        const node: Node = yield this.model.taskInstance;
+        const metadataSchema: MetadataNodeSchemaModel = yield this.store
+            .findRecord('metadata-node-schema', node.id);
+        this.set('metadataSchema', metadataSchema);
 
         this.set('defaultSchema', schemas.firstObject);
         this.set('selectedSchema', this.defaultSchema);

--- a/app/guid-node/metadata/template.hbs
+++ b/app/guid-node/metadata/template.hbs
@@ -23,6 +23,7 @@
                             @modelTaskInstance={{this.model.taskInstance}}
                             @relationshipName='registrations'
                             @showTags={{true}}
+                            @disableNodeLink={{true}}
                             @showExportCsvLink={{true}}
                             @metadataSchema={{this.metadataSchema}}
                             @showStatus={{false}}
@@ -127,6 +128,7 @@
                                 </ul>
                             {{/if}}
                         </div>
+                        <p class='NewReportModal__info'>{{t 'node.metadata.new_report_modal.note'}}</p>
                     </modal.body>
                     <modal.footer
                       data-test-new-report-modal-footer

--- a/lib/osf-components/addon/components/node-card/component.ts
+++ b/lib/osf-components/addon/components/node-card/component.ts
@@ -30,6 +30,7 @@ export default class NodeCard extends Component {
     readOnly: boolean = defaultTo(this.readOnly, false);
     showExportCsvLink: boolean = defaultTo(this.showExportCsvLink, false);
     showStatus: boolean = defaultTo(this.showStatus, true);
+    disableNodeLink: boolean = defaultTo(this.disableNodeLink, false);
 
     // Optional arguments
     metadataSchema?: MetadataNodeSchemaModel;

--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -30,7 +30,9 @@
                     {{/if}}
                 {{/if}}
                 {{node-card/node-icon category=@node.category}}
-                {{#if this.schemaUrl}}
+                {{#if this.disableNodeLink}}
+                    {{@node.title}}
+                {{else if this.schemaUrl}}
                     <OsfLink
                         data-analytics-name='Title'
                         data-test-node-title='{{@node.id}}'

--- a/lib/osf-components/addon/components/node-list/template.hbs
+++ b/lib/osf-components/addon/components/node-list/template.hbs
@@ -9,6 +9,7 @@
         <NodeCard
             @node={{node}}
             @showTags={{@showTags}}
+            @disableNodeLink={{@disableNodeLink}}
             @showExportCsvLink={{@showExportCsvLink}}
             @metadataSchema={{@metadataSchema}}
             @showStatus={{@showStatus}}

--- a/lib/osf-components/addon/components/osf-navbar/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/component.ts
@@ -26,12 +26,13 @@ interface ServiceLink {
     name: string;
     route?: string;
     href?: string;
+    disabled?: boolean;
 }
 
 export const OSF_SERVICES: ServiceLink[] = [
     { name: OSFService.HOME, route: 'home' },
     { name: OSFService.PREPRINTS, href: `${osfURL}preprints/` },
-    { name: OSFService.REGISTRIES, route: 'registries' },
+    { name: OSFService.REGISTRIES, route: 'registries', disabled: true },
     { name: OSFService.MEETINGS, route: 'meetings' },
     { name: OSFService.INSTITUTIONS, route: 'institutions' },
 ];
@@ -67,6 +68,9 @@ export default class OsfNavbar extends Component {
         const { currentRouteName } = this.router;
         if (activeService === OSFService.HOME && currentRouteName) {
             for (const osfService of OSF_SERVICES) {
+                if (osfService.disabled) {
+                    continue;
+                }
                 if (!osfService.route) {
                     continue;
                 }

--- a/lib/osf-components/addon/components/registration-report-export-button/component.ts
+++ b/lib/osf-components/addon/components/registration-report-export-button/component.ts
@@ -23,7 +23,13 @@ export default class RegistrationReportExportButton extends Component {
         if (!this.metadataSchema) {
             return [];
         }
-        return this.metadataSchema.formats;
+        return this.metadataSchema.formats
+            .filter(format => format.schema_id === this.registrationSchemaId);
+    }
+
+    @computed('metadataFormats')
+    get hasNoFormats(): boolean {
+        return this.metadataFormats.length === 0;
     }
 
     @action
@@ -31,8 +37,7 @@ export default class RegistrationReportExportButton extends Component {
         if (!this.metadataSchema || !this.exportCsvUrl) {
             return;
         }
-        const formats = this.metadataSchema.formats
-            .filter(format => format.schema_id === this.registrationSchemaId);
+        const formats = this.metadataFormats;
         if (formats.length === 0) {
             return;
         }

--- a/lib/osf-components/addon/components/registration-report-export-button/styles.scss
+++ b/lib/osf-components/addon/components/registration-report-export-button/styles.scss
@@ -3,3 +3,12 @@
         margin: 1.5em 0 1em;
     }
 }
+
+.Modal__title {
+    font-size: 24px;
+    font-weight: normal;
+}
+
+.Export__description {
+    margin: 1em 0;
+}

--- a/lib/osf-components/addon/components/registration-report-export-button/template.hbs
+++ b/lib/osf-components/addon/components/registration-report-export-button/template.hbs
@@ -7,8 +7,11 @@
     as |modal|
 >
     <modal.body data-analytics-scope='RegistrationReport modal'>
-        <div class='text-center'>
-            <h2 local-class='Modal__title'>{{ t 'metadata.registration-card.export-dialog.title' }}</h2>
+        <div>
+            <h4 local-class='Modal__title'>{{ t 'metadata.registration-card.export-dialog.title' }}</h4>
+        </div>
+        <div local-class='Export__description'>
+            {{t 'metadata.registration-card.export-dialog.description'}}
         </div>
         <div class='form-group'>
             <select id='registration-report-format-selection'>
@@ -23,24 +26,28 @@
     </modal.body>
     <modal.footer data-analytics-scope='RegistrationReport modal footer'>
         <OsfButton
+            data-test-registration-report-cancel
             data-analytics-name='Cancel'
             @onClick={{action modal.close}}
         >
             {{t 'general.cancel'}}
         </OsfButton>
         <OsfButton
+            data-test-registration-report-submit
             data-analytics-name='Submit'
             @type='success'
             @onClick={{action modal.submit}}
         >
-            {{t 'feedback.confirm_button_text'}}
+            {{t 'metadata.registration-card.export'}}
         </OsfButton>
     </modal.footer>
 </BsModal>
 
 <OsfButton
+    data-test-registration-card-export
     data-analytics-name='Export'
     @type='success'
+    @disabled={{this.hasNoFormats}}
     @onClick={{action this.export}}
 >
     {{t 'metadata.registration-card.export'}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
@@ -114,6 +114,7 @@
         component
         'registries/schema-block-renderer/editable/rdm/file-metadata-input'
         changeset=@changeset
+        onInput=@onInput
         node=@node
     )
 )}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-number-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-number-input/component.ts
@@ -28,20 +28,18 @@ export default class ERadAwardNumberInput extends Component {
     onInput!: () => void;
     onMetadataInput!: () => void;
 
-    candidates!: string[];
     anotherOption?: string;
 
     didReceiveAttrs() {
-        this.candidates = [...new Set(this.metadataNodeErad.records.map(rc => rc.kadai_id))];
         const current = this.changeset.get(this.valuePath);
-        if (!this.candidates.includes(current)) {
+        if (this.metadataNodeErad.records.every(rc => rc.kadai_id !== current)) {
             this.anotherOption = current;
         }
     }
 
     @computed('anotherOption')
     get options(): string[] {
-        const options: string[] = this.candidates.slice();
+        const options = this.metadataNodeErad.records.map(rc => this.getLocalizedItemText(rc));
         if (this.anotherOption) {
             options.push(this.anotherOption);
         }
@@ -50,32 +48,36 @@ export default class ERadAwardNumberInput extends Component {
 
     @action
     onChange(option: string) {
-        const eradRecords = this.metadataNodeErad.records.filter(rc => rc.kadai_id === option);
-        eradRecords.sort((a, b) => b.nendo - a.nendo);
-        if (eradRecords.length) {
-            this.updateCode('e-rad-award-funder-input', eradRecords[0].haibunkikan_cd);
-            this.updateCode('e-rad-award-field-input', eradRecords[0].bunya_cd);
+        const eradRecord = this.metadataNodeErad.records
+            .find(rc => this.getLocalizedItemText(rc) === option);
+        let kadaiId;
+        if (eradRecord) {
+            kadaiId = eradRecord.kadai_id;
+            this.updateCode('e-rad-award-funder-input', eradRecord.haibunkikan_cd);
+            this.updateCode('e-rad-award-field-input', eradRecord.bunya_cd);
             this.changeset.set(
                 this.draftManager.getResponseKeyByBlockType('e-rad-award-title-ja-input'),
-                eradRecords[0].kadai_mei,
+                eradRecord.kadai_mei,
             );
             this.changeset.set(
                 this.draftManager.getResponseKeyByBlockType('e-rad-award-title-en-input'),
-                eradRecords[0].kadai_mei,
+                eradRecord.kadai_mei,
             );
             this.metadataChangeset.set(
                 'title',
-                `${eradRecords[0].kadai_mei}`,
+                `${eradRecord.kadai_mei}`,
             );
+        } else {
+            kadaiId = option;
         }
-        this.changeset.set(this.valuePath, option);
+        this.changeset.set(this.valuePath, kadaiId);
         this.onMetadataInput();
         this.onInput();
     }
 
     @action
     onInputSearch(text: string) {
-        if (!this.candidates.includes(text) && this.anotherOption !== text) {
+        if (this.metadataNodeErad.records.every(rc => rc.kadai_id !== text) && this.anotherOption !== text) {
             this.set('anotherOption', text);
         }
         return true;
@@ -121,5 +123,12 @@ export default class ERadAwardNumberInput extends Component {
             return text;
         }
         return texts[2];
+    }
+
+    getLocalizedItemText(eradRecord: any) {
+        return `${eradRecord.kadai_id} | ${eradRecord.kadai_mei}`
+            + ` - ${eradRecord.haibunkikan_mei} | ${eradRecord.haibunkikan_cd}`
+            + ` - ${eradRecord.bunya_mei} | ${eradRecord.bunya_cd}`
+            + ` (${eradRecord.nendo})`;
     }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-number-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-number-input/component.ts
@@ -59,10 +59,6 @@ export default class ERadAwardNumberInput extends Component {
                 this.draftManager.getResponseKeyByBlockType('e-rad-award-title-ja-input'),
                 eradRecord.kadai_mei,
             );
-            this.changeset.set(
-                this.draftManager.getResponseKeyByBlockType('e-rad-award-title-en-input'),
-                eradRecord.kadai_mei,
-            );
             this.metadataChangeset.set(
                 'title',
                 `${eradRecord.kadai_mei}`,

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/styles.scss
@@ -1,18 +1,24 @@
 .file-metadata-input-container {
     width: 100%;
-    border: 1px solid #aaa;
+    border: 1px solid #eee;
     padding: 0.5em;
 }
 
-.file-metadata-input-header {
-    border: 1px solid #aaa;
-    padding: 0.5em;
-    background-color: #eee;
-    margin-bottom: 1em;
+.file-metadata-input-files {
+    border: 1px solid #eee;
 }
 
-.file-metadata-input-header h5 {
-    margin: 4px;
-    font-size: 1.5em;
-    font-weight: bold;
+.file-metadata-input-files th {
+    border: 1px solid #eee;
+    background: #f5f5f5;
+    height: 35px;
+}
+
+.file-metadata-input-files td {
+    border-top: 1px solid #eee;
+    height: 35px;
+}
+
+.file-metadata-input-edit-button {
+    padding: 0 !important;
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/template.hbs
@@ -1,32 +1,83 @@
 <Registries::SchemaBlockRenderer::Editable::Base @helpText={{this.schemaBlock.helpText}}>
-    <div local-class='file-metadata-input-container'>
-        <div local-class='file-metadata-input-header'>
-            <h5>{{this.node.title}}</h5>
-        </div>
-        {{#if this.fileEntries}}
-            <ul>
+    {{#if this.fileEntries}}
+        <table local-class='file-metadata-input-files'>
+            <thead>
+                <tr>
+                    <th class='col-md-4'>
+                        {{t 'metadata.file-metadata-input.columns.title'}}
+                    </th>
+                    <th class='col-md-3'>
+                        {{t 'metadata.file-metadata-input.columns.path'}}
+                    </th>
+                    <th class='col-md-3'>
+                        {{t 'metadata.file-metadata-input.columns.manager'}}
+                    </th>
+                    <th class='col-md-2'></th>
+                </tr>
+            </thead>
+            <tbody>
                 {{#each this.fileEntries as |fileEntry|}}
-                    <li>
-                        <span local-class='file-metadata-item-title'>
-                            {{fileEntry.title}}
-                        </span>
-                        {{#if fileEntry.url}}
-                            <a href='{{fileEntry.url}}' target='_blank' rel='noopener'>
-                                {{fileEntry.url}}
+                    <tr>
+                        <td class='col-md-4'>
+                            {{#if fileEntry.url}}
+                                <a href='{{fileEntry.url}}' target='_blank' rel='noopener'>
+                                    {{fileEntry.title}}
+                                </a>
+                            {{else}}
+                                {{fileEntry.title}}
+                            {{/if}}
+                        </td>
+                        <td class='col-md-3'>
+                            {{fileEntry.path}}
+                        </td>
+                        <td class='col-md-3'>
+                            {{#if fileEntry.manager}}
+                                {{fileEntry.manager}}
+                            {{else}}
+                                {{t 'metadata.file-metadata-input.no_manager'}}
+                            {{/if}}
+                        </td>
+                        <td class='col-md-2'>
+                            <a
+                                data-test-file-metadata-input-edit
+                                class='btn btn-link'
+                                local-class='file-metadata-input-edit-button'
+                                href='{{fileEntry.fileUrl}}'
+                                target='_blank'
+                                rel='noopener'>
+                                <i class='fa fa-edit'></i>
                             </a>
-                        {{else}}
-                            <a href='{{fileEntry.fileUrl}}' target='_blank' rel='noopener'>
-                                {{fileEntry.path}}
-                            </a>
-                        {{/if}}
-                    </li>
+                            {{#if fileEntry.canMoveUpper}}
+                                <button
+                                    data-test-file-metadata-input-upper
+                                    class='btn btn-link'
+                                    local-class='file-metadata-input-edit-button'
+                                    {{action this.moveUpper fileEntry}}
+                                >
+                                    <i class='fa fa-chevron-up'></i>
+                                </button>
+                            {{/if}}
+                            {{#if fileEntry.canMoveLower}}
+                                <button
+                                    data-test-file-metadata-input-upper
+                                    class='btn btn-link'
+                                    local-class='file-metadata-input-edit-button'
+                                    {{action this.moveLower fileEntry}}
+                                >
+                                    <i class='fa fa-chevron-down'></i>
+                                </button>
+                            {{/if}}
+                        </td>
+                    </tr>
                 {{/each}}
-            </ul>
-        {{else}}
+            </tbody>
+        </table>
+    {{else}}
+        <div local-class='file-metadata-input-container'>
             {{t 'metadata.file-metadata-input.no_metadata_editable'}}
             <a href='{{this.nodeUrl}}' target='_blank' rel='noopener'>
                 {{this.nodeUrl}}
             </a>
-        {{/if}}
-    </div>
+        </div>
+    {{/if}}
 </Registries::SchemaBlockRenderer::Editable::Base>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/file-metadata-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/file-metadata-input/styles.scss
@@ -1,18 +1,24 @@
 .file-metadata-input-container {
     width: 100%;
-    border: 1px solid #aaa;
+    border: 1px solid #eee;
     padding: 0.5em;
 }
 
-.file-metadata-input-header {
-    border: 1px solid #aaa;
-    padding: 0.5em;
-    background-color: #eee;
-    margin-bottom: 1em;
+.file-metadata-input-files {
+    border: 1px solid #eee;
 }
 
-.file-metadata-input-header h5 {
-    margin: 4px;
-    font-size: 1.5em;
-    font-weight: bold;
+.file-metadata-input-files th {
+    border: 1px solid #eee;
+    background: #f5f5f5;
+    height: 35px;
+}
+
+.file-metadata-input-files td {
+    border-top: 1px solid #eee;
+    height: 35px;
+}
+
+.file-metadata-input-edit-button {
+    padding: 0 !important;
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/file-metadata-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/file-metadata-input/template.hbs
@@ -1,33 +1,49 @@
-<div local-class='file-metadata-input-container'>
-    <div local-class='file-metadata-input-header'>
-        <h5>{{this.node.title}}</h5>
-        <a href='{{this.nodeUrl}}' target='_blank' rel='noopener'>
-            {{this.nodeUrl}}
-        </a>
-    </div>
-    {{#if this.fileEntries}}
-        <ul>
+{{#if this.fileEntries}}
+    <table local-class='file-metadata-input-files'>
+        <thead>
+            <tr>
+                <th class='col-md-4'>
+                    {{t 'metadata.file-metadata-input.columns.title'}}
+                </th>
+                <th class='col-md-3'>
+                    {{t 'metadata.file-metadata-input.columns.path'}}
+                </th>
+                <th class='col-md-5'>
+                    {{t 'metadata.file-metadata-input.columns.manager'}}
+                </th>
+            </tr>
+        </thead>
+        <tbody>
             {{#each this.fileEntries as |fileEntry|}}
-                <li>
-                    <span local-class='file-metadata-item-title'>
-                        {{fileEntry.title}}
-                    </span>
-                    {{#if fileEntry.url}}
-                        <a href='{{fileEntry.url}}' target='_blank' rel='noopener'>
-                            {{fileEntry.url}}
-                        </a>
-                    {{else}}
-                        <a href='{{this.nodeUrl}}/files/' target='_blank' rel='noopener'>
-                            {{fileEntry.path}}
-                        </a>
-                    {{/if}}
-                </li>
+                <tr>
+                    <td class='col-md-4'>
+                        {{#if fileEntry.url}}
+                            <a href='{{fileEntry.url}}' target='_blank' rel='noopener'>
+                                {{fileEntry.title}}
+                            </a>
+                        {{else}}
+                            {{fileEntry.title}}
+                        {{/if}}
+                    </td>
+                    <td class='col-md-3'>
+                        {{fileEntry.path}}
+                    </td>
+                    <td class='col-md-5'>
+                        {{#if fileEntry.manager}}
+                            {{fileEntry.manager}}
+                        {{else}}
+                            {{t 'metadata.file-metadata-input.no_manager'}}
+                        {{/if}}
+                    </td>
+                </tr>
             {{/each}}
-        </ul>
-    {{else}}
+        </tbody>
+    </table>
+{{else}}
+    <div local-class='file-metadata-input-container'>
         {{t 'metadata.file-metadata-input.no_metadata'}}
-    {{/if}}
-</div>
+    </div>
+{{/if}}
 {{#if @changeset}}
     <ValidationErrors
       local-class='ValidationErrors'

--- a/lib/registries/addon/application/controller.ts
+++ b/lib/registries/addon/application/controller.ts
@@ -20,7 +20,7 @@ export default class Application extends Controller {
     @service features!: Features;
     @alias(`features.${camelize(newStyleFlag)}`) newStyleEnabled!: boolean;
 
-    activeService = OSFService.REGISTRIES;
+    activeService = OSFService.HOME;
     searchRoute = 'registries.discover';
     supportRoute = 'https://openscience.zendesk.com/hc/en-us/categories/360001550953';
 

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1761,7 +1761,7 @@ iqbrims:
     files_comment: 'コメント'
     uploader_comment: 'コメント'
 binderhub:
-    page_title: '{nodeTitle} BidnerHub'
+    page_title: '{nodeTitle} BinderHub'
     jupyter_servers_list:
         header: 'My environments'
         delete_confirm_dialog_title: 'Delete confirmation'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -635,17 +635,18 @@ node:
         draft_registrations: 'Draft Registrations'
     metadata:
         new_report_modal:
-            title: Metadata
+            title: Select metadata schema
             info: 'Select the schema of the metadata you wish to create from the following:<ul><li>Metadata can be filled in with items defined in the schema.</li><li>You can register metadata for files included in this project in the metadata.</li><li>Files compliant with the report format can be downloaded from the metadata and used for the application.</li></ul>'
+            note: '*Metadata forms will be constantly added as the number of corresponding projects and institutions grows in the future.'
             create: 'Create Metadata'
         page_title: '{nodeTitle} Metadata'
         only_admins_can_initiate: 'Only project administrators can initiate metadata.'
         no_reports: 'There are no metadata of this project.'
         no_drafts: 'There are no draft metadata of this project.'
-        start_new: 'Start to edit a new metadata by clicking the “New metadata” button. Once created, metadata cannot be edited or deleted.'
+        start_new: 'Start to edit a new metadata by clicking the “Create new metadata” button. Once created, metadata cannot be edited or deleted.'
         register_entire_project: 'To register the entire project "{rootNodeTitle}" instead, click'
         here: here
-        new: 'New metadata'
+        new: 'Create new metadata'
         reports: Metadata
         draft_reports: 'Draft Metadata'
 delete_modal:
@@ -1824,9 +1825,15 @@ metadata:
     file-metadata-input:
         no_metadata: 'No files'
         no_metadata_editable: 'File metadata is not registered. You can edit the file metadata on the project page and register it in this draft:'
+        columns:
+            title: 'Title'
+            path: 'Path'
+            manager: 'Manager'
+        no_manager: '-'
     draft-registration-card:
         export: 'Export'
     registration-card:
         export: 'Export'
         export-dialog:
             title: 'Select a report format'
+            description: 'Select the report format you want to output.'

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -1761,7 +1761,7 @@ iqbrims:
     files_comment: コメント
     uploader_comment: コメント
 binderhub:
-    page_title: '{nodeTitle} BidnerHub'
+    page_title: '{nodeTitle} BinderHub'
     jupyter_servers_list:
         header: '私の解析環境'
         delete_confirm_dialog_title: '削除確認'

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -635,19 +635,20 @@ node:
         draft_registrations: ドラフト登録
     metadata:
         new_report_modal:
-            title: メタデータ
-            info: '新規に作成したいメタデータのスキーマ(様式)を以下から選択してください。<ul><li>メタデータにはスキーマに定義された項目を入力することができます。</li><li>メタデータには、このプロジェクトに含まれるファイルのメタデータを登録することができます。</li><li>メタデータから報告書様式に準拠したファイルをダウンロードし、申請に利用することができます。</li></ul>'
+            title: メタデータ様式を選択
+            info: '新規に作成したいメタデータの様式を以下から選択してください。<ul><li>メタデータ作成では、様式で定義された各項目を入力することができます。</li><li>メタデータ作成では、このプロジェクトに含まれるファイルのメタデータを登録することができます。</li><li>メタデータ作成から報告書様式に準拠したファイルをダウンロードし、報告書等の提出に利用することができます。</li></ul>'
+            note: ＊今後、対応する事業や機関の増加に合わせて、メタデータの様式は随時追加されていきます。
             create: メタデータを作成
         page_title: '{nodeTitle} メタデータ'
         only_admins_can_initiate: プロジェクト管理者のみがメタデータ作成を開始できます。
         no_reports: このプロジェクトのメタデータはありません。
-        no_drafts: このプロジェクトのドラフトメタデータはありません。
-        start_new: '「新規メタデータ」ボタンをクリックして、新規メタデータ作成を開始します。登録したメタデータは、編集または削除できません。'
+        no_drafts: このプロジェクトに関する下書きはありません。
+        start_new: '「新規メタデータを作成」ボタンをクリックして、新規メタデータ作成を開始します。一度登録したメタデータを、編集または削除することはできません。'
         register_entire_project: '代わりにプロジェクト"{rootNodeTitle}"全体を報告するには、クリックします。'
         here: こちら
-        new: 新規メタデータ
+        new: 新規メタデータを作成
         reports: メタデータ
-        draft_reports: ドラフトメタデータ
+        draft_reports: 下書き
 delete_modal:
     title: 'この{nodeType}を削除してもよろしいですか？'
     body: '{nodeType}の他の投稿者は利用できなくなります。'
@@ -1000,9 +1001,9 @@ registries:
         help:
             title: 登録フォームの選択を支援
     drafts:
-        page_title: 登録ドラフトを表示
+        page_title: 下書きを表示
         index:
-            title: 未完成のドラフトを選択
+            title: 未完成の下書きを選択
         draft:
             metadata:
                 title: 基本的な登録情報を記入してください
@@ -1365,11 +1366,11 @@ routes:
 osf-components:
     draft-registration-card:
         initiated_by: '開始したユーザ:'
-        form_type: 'スキーマ:'
+        form_type: '様式:'
         started: '開始日:'
         last_updated: '最終更新日:'
         review: 内容確認
-        delete_draft_confirm: このドラフト登録を削除してもよろしいですか？
+        delete_draft_confirm: この下書きを削除してもよろしいですか？
     copyable-text:
         copyToClipboard: クリップボードへコピー
         copied: コピー済み
@@ -1823,10 +1824,16 @@ binderhub:
 metadata:
     file-metadata-input:
         no_metadata: 'ファイルはありません'
-        no_metadata_editable: 'ファイルメタデータは登録されていません。プロジェクトページでファイルのメタデータを編集し、このドラフトに登録することができます:'
+        no_metadata_editable: 'ファイルメタデータは登録されていません。プロジェクトページでファイルのメタデータを編集し、この下書きに登録することができます:'
+        columns:
+            title: 'タイトル'
+            path: 'パス'
+            manager: '管理者'
+        no_manager: '-'
     draft-registration-card:
         export: 'エクスポート'
     registration-card:
         export: 'エクスポート'
         export-dialog:
             title: '報告書フォーマットの選択'
+            description: '出力したい報告書のフォーマットを選択してください。'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: GRDM-31485,GRDM-31190,GRDM-31645
- Feature flag: n/a

## Purpose

メタデータ, BinderHubアドオンに関する複数の修正。

## Summary of Changes

- [GRDM-31485] バグ RCOS環境でエクスポートボタンが押しても何も起きない の修正 - yieldを追加
- [GRDM-31190] 案内文章の修正
- [GRDM-31645] バグ Data Science NotebookにてGRDMコンテンツのディレクトリ構造が失われる の修正

## Side Effects

None

## QA Notes

None