### PR TITLE
[GRDM-32991] BinderHub アドオンでコピーしたファイルの所有者がjovyanになるよう修正

### DIFF
--- a/app/guid-node/binderhub/-components/project-editor/component.ts
+++ b/app/guid-node/binderhub/-components/project-editor/component.ts
@@ -341,7 +341,7 @@ export default class ProjectEditor extends Component {
             content += 'RUN /postBuild\n';
             content += '\n';
         }
-        content += 'COPY . .\n';
+        content += 'COPY --chown=$NB_UID:$NB_GID . .\n';
         const checksum = md5(content.trim());
         return `# rdm-binderhub:hash:${checksum}\n${content}`;
     }


### PR DESCRIPTION
- Ticket: GRDM-32991
- Feature flag: n/a

## Purpose

BinderHub アドオンでコピーしたファイル・フォルダの所有者が jovyan:users になるよう修正しました。

## Summary of Changes

- [GRDM-32991] Dockerfile 内の COPY 命令に所有者変更オプションを追加

## Side Effects
None

## QA Notes
None
