### PR TITLE
[GRDM-33624] /registriesポータルサイトの停止

### DIFF
--- a/lib/registries/addon/discover/route.ts
+++ b/lib/registries/addon/discover/route.ts
@@ -1,14 +1,18 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
+import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 
 import Analytics from 'ember-osf-web/services/analytics';
 
 export default class RegistriesDiscoverRoute extends Route {
     @service analytics!: Analytics;
+    @service router!: RouterService;
 
     @action
     didTransition() {
         this.analytics.trackPage();
+        // registries page is disabled for metadata addon
+        this.router.transitionTo('/');
     }
 }

--- a/lib/registries/addon/index/route.ts
+++ b/lib/registries/addon/index/route.ts
@@ -1,14 +1,18 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
+import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 
 import Analytics from 'ember-osf-web/services/analytics';
 
 export default class RegistriesIndexRoute extends Route {
     @service analytics!: Analytics;
+    @service router!: RouterService;
 
     @action
     didTransition() {
         this.analytics.trackPage();
+        // registries page is disabled for metadata addon
+        this.router.transitionTo('/');
     }
 }

--- a/lib/registries/addon/index/template.hbs
+++ b/lib/registries/addon/index/template.hbs
@@ -1,8 +1,3 @@
-<script>
-    {{!-- template-lint-disable no-bare-strings --}}
-    window.location = '/';
-</script>
-
 <ScheduledBanner />
 
 {{#registries-header onSearch=(action 'onSearch') searchable=this.searchableRegistrations as |header|}}

--- a/tests/engines/registries/acceptance/landing-page-test.ts
+++ b/tests/engines/registries/acceptance/landing-page-test.ts
@@ -4,8 +4,8 @@ import { percySnapshot } from 'ember-percy';
 import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 
+import { currentURL, visit } from '@ember/test-helpers';
 import { stubRegistriesShareSearch } from 'ember-osf-web/tests/engines/registries/helpers';
-import { visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
 
 // TODO: more thorough tests (these are just for percy's sake)
@@ -24,13 +24,17 @@ module('Registries | Acceptance | landing page', hooks => {
 
     test('visiting /registries/', async assert => {
         await visit('/registries/');
-        assert.dom('[data-test-search-box]').exists();
+        // registries page is disabled for metadata addon
+        // assert.dom('[data-test-search-box]').exists();
+        assert.equal(currentURL(), '/', 'redirected to home');
         await percySnapshot(assert);
     });
 
     test('visiting /registries/discover', async assert => {
         await visit('/registries/discover/');
-        assert.dom('[data-test-results]').exists();
+        // registries page is disabled for metadata addon
+        // assert.dom('[data-test-results]').exists();
+        assert.equal(currentURL(), '/', 'redirected to home');
         await percySnapshot(assert);
     });
 });

--- a/tests/engines/registries/integration/discover/discover-test.ts
+++ b/tests/engines/registries/integration/discover/discover-test.ts
@@ -349,6 +349,10 @@ const AnalyticsTestCases: Array<{
     }];
 
 module('Registries | Integration | discover', hooks => {
+    // registries page is disabled for metadata addon
+    return;
+
+    /* eslint-disable no-unreachable */
     setupOSFApplicationTest(hooks);
     setupMirage(hooks);
 
@@ -641,4 +645,6 @@ module('Registries | Integration | discover', hooks => {
             }),
         }));
     });
+
+    /* eslint-enable no-unreachable */
 });


### PR DESCRIPTION
- Ticket: [GRDM-33624]
- Feature flag: n/a

## Purpose

/registries ポータルサイトを停止しました。

## Summary of Changes

- script タグ埋め込みの代わりに route.ts でリダイレクトするよう変更しました。
- テストを修正しました。

## Side Effects

None

## QA Notes

None