### PR TITLE
[GRDM-34189] 登録データ画面におけるリロードボタン実装

### DIFF
--- a/app/packages/registration-schema/page-manager.ts
+++ b/app/packages/registration-schema/page-manager.ts
@@ -42,6 +42,13 @@ export class PageManager {
         }
     }
 
+    setChangesetValue(valuePath: string, value: any) {
+        if (this.changeset) {
+            this.changeset.set(valuePath, value);
+            this.changeset.validate();
+        }
+    }
+
     @computed('changeset.isValid')
     get pageIsValid() {
         if (this.changeset) {

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
@@ -116,5 +116,6 @@
         changeset=@changeset
         onInput=@onInput
         node=@node
+        draftManager=@draftManager
     )
 )}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/component.ts
@@ -12,6 +12,7 @@ import { layout } from 'ember-osf-web/decorators/component';
 import NodeModel from 'ember-osf-web/models/node';
 import pathJoin from 'ember-osf-web/utils/path-join';
 
+import DraftRegistrationManager from 'registries/drafts/draft/draft-registration-manager';
 import styles from './styles';
 import template from './template';
 
@@ -50,6 +51,7 @@ export default class FileMetadataInput extends Component {
     // Required param
     changeset!: ChangesetDef;
     node!: NodeModel;
+    draftManager!: DraftRegistrationManager;
 
     @alias('schemaBlock.registrationResponseKey')
     valuePath!: string;
@@ -127,6 +129,14 @@ export default class FileMetadataInput extends Component {
     @action
     moveLower(this: FileMetadataInput, entry: FileEntry) {
         this.changeIndex(entry.path, 1);
+    }
+
+    @action
+    async reloadFileEntries() {
+        const draftRegistration = await this.draftManager.draftRegistration.reload();
+        const { registrationResponses } = draftRegistration;
+        this.draftManager.setChangesetValue(this.valuePath, registrationResponses[this.valuePath]);
+        this.notifyPropertyChange('changeset');
     }
 
     extractTitleFromMetadata(metadata: FileMetadata): string | null {

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/styles.scss
@@ -22,3 +22,7 @@
 .file-metadata-input-edit-button {
     padding: 0 !important;
 }
+
+.file-metadata-input-buttons {
+    margin-bottom: 4px;
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/template.hbs
@@ -1,4 +1,14 @@
 <Registries::SchemaBlockRenderer::Editable::Base @helpText={{this.schemaBlock.helpText}}>
+    <div local-class='file-metadata-input-buttons'>
+        <OsfButton
+          data-test-file-metadata-input-reload
+          @onClick={{action this.reloadFileEntries}}
+          local-class='file-metadata-input-reload-button'
+        >
+            {{fa-icon 'rotate-right'}}
+            {{t 'metadata.file-metadata-input.reload'}}
+        </OsfButton>
+    </div>
     {{#if this.fileEntries}}
         <table local-class='file-metadata-input-files'>
             <thead>

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -254,4 +254,11 @@ export default class DraftRegistrationManager {
         }
         return block.registrationResponseKey;
     }
+
+    setChangesetValue(valuePath: string, value: any) {
+        this.pageManagers
+            .forEach(pageManager => {
+                pageManager.setChangesetValue(valuePath, value);
+            });
+    }
 }

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1832,6 +1832,7 @@ metadata:
             path: 'Path'
             manager: 'Manager'
         no_manager: '-'
+        reload: 'Reload'
     draft-registration-card:
         export: 'Export'
     registration-card:

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -1832,6 +1832,7 @@ metadata:
             path: 'パス'
             manager: '管理者'
         no_manager: '-'
+        reload: '更新'
     draft-registration-card:
         export: 'エクスポート'
     registration-card:


### PR DESCRIPTION
## Purpose
メタデータ編集における登録データ画面でリロードボタンを実装しました。

## Changes

- [GRDM-34189] リロードボタンを実装しました。

## QA Notes
None

## Documentation
None

## Side Effects
None

## Ticket
GRDM-34189
