### PR TITLE
[GRDM-35282, GRDM-31366, GRDM-31368] BinderHubアドオンの修正

### DIFF
--- a/app/guid-node/binderhub/-components/jupyter-servers-list/component.ts
+++ b/app/guid-node/binderhub/-components/jupyter-servers-list/component.ts
@@ -395,12 +395,17 @@ export default class JupyterServersList extends Component {
         if (!jupyterhub || !jupyterhub.token || !validateJupyterHubToken(jupyterhub)) {
             throw new EmberError('Not authorized');
         }
-        const response = await this.jupyterhubAPIAJAX(jupyterhubUrl, `users/${jupyterhub.token.user}`);
+        const response = await this.jupyterhubAPIAJAX(
+            jupyterhubUrl,
+            `users/${jupyterhub.token.user}?include_stopped_servers=1`,
+        );
         const result = response as any;
         if (result.servers === undefined || result.servers === null) {
             throw new EmberError('Unexpected object');
         }
-        const serverNames: string[] = Object.keys(result.servers).map(key => key as string);
+        const serverNames: string[] = Object.keys(result.servers)
+            .map(key => key as string)
+            .filter(key => key.length > 0);
         serverNames.sort();
         return serverNames
             .map(serverName => result.servers[serverName] as JupyterServer)

--- a/app/guid-node/binderhub/-components/jupyter-servers-list/component.ts
+++ b/app/guid-node/binderhub/-components/jupyter-servers-list/component.ts
@@ -15,6 +15,11 @@ export interface JupyterServerOptions {
     rdm_node?: string;
 }
 
+interface JupyterUser {
+    named_server_limit?: number | null;
+    servers?: {[key: string]: JupyterServer} | null;
+}
+
 export interface JupyterServer {
     name: string;
     last_activity?: string | null;
@@ -28,6 +33,11 @@ export interface JupyterServer {
 interface JupyterServerEntry {
     ownerUrl: string;
     entry: JupyterServer;
+}
+
+interface JupyterServerResponse {
+    namedServerLimit: number | null;
+    entries: JupyterServerEntry[];
 }
 
 export interface SelectableBinderhub {
@@ -127,6 +137,8 @@ export default class JupyterServersList extends Component {
 
     loggedOutDomains: string[] | null = null;
 
+    namedServerLimit: number | null = null;
+
     didReceiveAttrs() {
         const bhubUrl = getContext('jh');
         if (!this.selectedBinderhubUrl && bhubUrl) {
@@ -175,20 +187,30 @@ export default class JupyterServersList extends Component {
         return servers.filter(server => this.isTarget(server.entry));
     }
 
-    @computed('allServers', 'defaultJupyterhub')
-    get maxServersExceeded(): boolean {
+    get maxServers(): number | null {
+        if (this.namedServerLimit !== null) {
+            return this.namedServerLimit;
+        }
         const jupyterhub = this.defaultJupyterhub;
         if (!jupyterhub) {
-            return false;
+            return null;
         }
         if (jupyterhub.max_servers === null || jupyterhub.max_servers === undefined) {
-            return false;
+            return null;
         }
+        return jupyterhub.max_servers;
+    }
+
+    @computed('allServers', 'defaultJupyterhub')
+    get maxServersExceeded(): boolean {
         const servers = this.allServers;
         if (servers === null) {
             return false;
         }
-        return servers.length >= jupyterhub.max_servers;
+        if (this.maxServers === null) {
+            return false;
+        }
+        return servers.length >= this.maxServers;
     }
 
     @computed('defaultJupyterhub')
@@ -325,11 +347,13 @@ export default class JupyterServersList extends Component {
     performLoadServers(jupyterhubUrl: string) {
         this.set('allServers', null);
         this.set('serversLink', null);
+        this.set('namedServerLimit', null);
         later(async () => {
             const servers = await this.loadServers(jupyterhubUrl);
             const homeUrl = addPathSegment(jupyterhubUrl, 'hub/home');
             this.set('serversLink', homeUrl);
-            this.set('allServers', servers);
+            this.set('allServers', servers !== null ? servers.entries : null);
+            this.set('namedServerLimit', servers !== null ? servers.namedServerLimit : null);
         }, 0);
     }
 
@@ -382,7 +406,7 @@ export default class JupyterServersList extends Component {
         }
     }
 
-    async loadServers(jupyterhubUrl: string): Promise<JupyterServerEntry[] | null> {
+    async loadServers(jupyterhubUrl: string): Promise<JupyterServerResponse | null> {
         if (!this.binderHubConfig || !this.binderHubConfig.get('isFulfilled')) {
             throw new EmberError('Illegal config');
         }
@@ -399,20 +423,24 @@ export default class JupyterServersList extends Component {
             jupyterhubUrl,
             `users/${jupyterhub.token.user}?include_stopped_servers=1`,
         );
-        const result = response as any;
-        if (result.servers === undefined || result.servers === null) {
+        const result = response as JupyterUser;
+        const { servers } = result;
+        if (servers === undefined || servers === null) {
             throw new EmberError('Unexpected object');
         }
-        const serverNames: string[] = Object.keys(result.servers)
+        const serverNames: string[] = Object.keys(servers)
             .map(key => key as string)
             .filter(key => key.length > 0);
         serverNames.sort();
-        return serverNames
-            .map(serverName => result.servers[serverName] as JupyterServer)
-            .map(server => ({
-                ownerUrl: jupyterhubUrl,
-                entry: server,
-            }));
+        return {
+            namedServerLimit: result.named_server_limit !== undefined ? result.named_server_limit : null,
+            entries: serverNames
+                .map(serverName => servers[serverName] as JupyterServer)
+                .map(server => ({
+                    ownerUrl: jupyterhubUrl,
+                    entry: server,
+                })),
+        };
     }
 
     isTarget(server: JupyterServer) {
@@ -508,7 +536,7 @@ export default class JupyterServersList extends Component {
                 },
             );
             const servers = await this.loadServers(server.ownerUrl);
-            this.set('allServers', servers);
+            this.set('allServers', servers !== null ? servers.entries : null);
         }, 0);
     }
 

--- a/app/guid-node/binderhub/-components/jupyter-servers-list/template.hbs
+++ b/app/guid-node/binderhub/-components/jupyter-servers-list/template.hbs
@@ -52,7 +52,7 @@
                         }}
                     {{/if}}
                     {{#if this.maxServersExceeded}}
-                        <strong local-class='max-servers-exceeded'>
+                        <strong data-test-max-servers-exceeded local-class='max-servers-exceeded'>
                             {{t 'binderhub.servers.max_servers_exceeded'}}
                         </strong>
                     {{/if}}
@@ -88,7 +88,7 @@
                     {{fa-icon 'fa-undo'}}
                 </button>
             </div>
-            <table class='table table-responsive'>
+            <table class='table table-responsive' data-test-server-list>
                 <thead>
                     <tr>
                         <th class='col-md-2'>{{t 'binderhub.servers.name'}}</th>
@@ -100,9 +100,9 @@
                 </thead>
                 <tbody local-class='jupyter-server'>
                     {{#if this.servers.length}}
-                        {{#each this.servers as |server|}}
+                        {{#each this.servers as |server index|}}
                             <tr>
-                                <td class='col-md-2'>{{server.entry.name}}</td>
+                                <td class='col-md-2' data-test-server-list-item={{index}}>{{server.entry.name}}</td>
                                 <td class='col-md-3'>
                                     {{#if server.entry.ready}}
                                         <button

--- a/app/guid-node/binderhub/-components/package-editor/template.hbs
+++ b/app/guid-node/binderhub/-components/package-editor/template.hbs
@@ -14,11 +14,13 @@
             <div local-class='package_item'>
                 {{#if this.node.userHasWritePermission}}
                     <button
+                        data-test-package-edit-item={{index}}
                         {{action this.editPackage index target=this}}
                     >
                         {{pkg.[0]}}:{{pkg.[1]}}
                     </button>
                     <button
+                        data-test-package-delete-item={{index}}
                         {{action this.removePackage index target=this}}
                     >
                         <i class='fa fa-times' />

--- a/tests/acceptance/guid-node/binderhub-test.ts
+++ b/tests/acceptance/guid-node/binderhub-test.ts
@@ -1,4 +1,4 @@
-import { currentRouteName } from '@ember/test-helpers';
+import { click, currentRouteName, fillIn } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { percySnapshot } from 'ember-percy';
 import { module, test } from 'qunit';
@@ -109,7 +109,7 @@ module('Acceptance | guid-node/binderhub', hooks => {
         assert.dom('[data-test-package-editor="pip"]').doesNotExist();
 
         assert.ok(
-            ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser', null),
+            ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser?include_stopped_servers=1', null),
             'BinderHub calls JupyterHub REST API',
         );
 
@@ -233,7 +233,7 @@ module('Acceptance | guid-node/binderhub', hooks => {
             'BinderHub retrieves Dockerfile data',
         );
         assert.ok(
-            ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser', null),
+            ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser?include_stopped_servers=1', null),
             'BinderHub calls JupyterHub REST API',
         );
 
@@ -354,7 +354,591 @@ module('Acceptance | guid-node/binderhub', hooks => {
             'BinderHub retrieves Dockerfile data',
         );
         assert.ok(
-            ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser', null),
+            ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser?include_stopped_servers=1', null),
+            'BinderHub calls JupyterHub REST API',
+        );
+
+        sandbox.restore();
+    });
+
+    test('already configured, pip on Dockerfile', async assert => {
+        const node = server.create('node', {
+            id: 'i9bri',
+            currentUserPermissions: [Permission.Write],
+        });
+        server.create('binderhub-config', {
+            id: node.id,
+            binderhubs: [{
+                default: true,
+                url: 'http://localhost:8585/',
+                authorize_url: 'http://localhost/authorize',
+                token: {
+                    access_token: 'TESTBHTOKEN',
+                    token_type: 'Bearer',
+                    expires_at: null,
+                },
+                jupyterhub_url: 'http://localhost:30123/',
+            }],
+            jupyterhubs: [{
+                url: 'http://localhost:30123/',
+                api_url: 'http://localhost:30123/hub/api/',
+                authorize_url: 'http://localhost/authorize',
+                token: {
+                    user: 'testuser',
+                    access_token: 'TESTJHTOKEN',
+                    token_type: 'Bearer',
+                    expires_at: null,
+                },
+            }],
+            node_binderhubs: [
+                {
+                    binderhub_url: 'http://localhost:8585/',
+                    jupyterhub_url: 'http://localhost:30123/',
+                },
+            ],
+            user_binderhubs: [],
+            deployment: {
+                images: [
+                    {
+                        url: 'jupyter/scipy-notebook',
+                        name: 'Test Image',
+                        description: 'dummy description',
+                        packages: ['conda', 'pip'],
+                    },
+                    {
+                        url: '#repo2docker#r-base',
+                        name: 'Test Repo2Docker',
+                        description: 'dummy description',
+                        packages: ['conda', 'pip', 'rmran'],
+                    },
+                ],
+            },
+            launcher: {
+                endpoints: [
+                    {
+                        id: 'fake',
+                        name: 'Fake',
+                        path: 'Fake',
+                    },
+                ],
+            },
+        });
+        const osfstorage = server.create('file-provider',
+            { node, name: 'osfstorage' });
+        const binderFolder = server.create('file', { target: node }, 'asFolder');
+        binderFolder.update({
+            name: '.binder',
+        });
+        server.create('file',
+            {
+                target: node,
+                name: 'a',
+                dateModified: new Date(2019, 3, 3),
+                parentFolder: binderFolder,
+            });
+        server.create('file',
+            {
+                target: node,
+                name: 'Dockerfile',
+                dateModified: new Date(2019, 2, 2),
+                parentFolder: binderFolder,
+            });
+        osfstorage.rootFolder.update({
+            files: [binderFolder],
+        });
+        const sandbox = sinon.createSandbox();
+        const ajaxStub = sandbox.stub(BinderHubConfigModel.prototype, 'jupyterhubAPIAJAX');
+        ajaxStub.resolves({
+            kind: 'user',
+            name: 'testuser',
+            servers: {},
+        });
+        const getContentsStub = sandbox.stub(FileModel.prototype, 'getContents');
+        const toStringStub = sinon.stub();
+        toStringStub.returns('# rdm-binderhub:hash:8a89cc5c3fed08d4da5a7b7396733b53\n'
+            + 'FROM jupyter/scipy-notebook\n\nCOPY --chown=$NB_UID:$NB_GID . .\n');
+        getContentsStub.resolves({ toString: toStringStub });
+        const updateContentsStub = sandbox.stub(FileModel.prototype, 'updateContents');
+        const url = `/${node.id}/binderhub`;
+
+        await visit(url);
+        assert.equal(currentURL(), url, `We are on ${url}`);
+        assert.equal(currentRouteName(), 'guid-node.binderhub', 'We are at guid-node.binderhub');
+        await percySnapshot(assert);
+        assert.dom('[data-test-servers-header]').exists();
+        assert.dom('[data-test-binderhub-header]').exists();
+        assert.dom('[data-test-jupyterhub-selection-option]').exists({ count: 1 });
+        assert.dom('[data-test-binderhub-launch]').exists();
+        assert.dom('[data-test-image-change="jupyter/scipy-notebook"]').exists();
+        assert.dom('[data-test-image-selected="jupyter/scipy-notebook"]').exists();
+        assert.dom('[data-test-image-selection]').doesNotExist();
+        assert.dom('[data-test-package-editor="apt"]').exists();
+        assert.dom('[data-test-package-editor="conda"]').exists();
+        assert.dom('[data-test-package-editor="pip"]').exists();
+        assert.dom('[data-test-package-editor="rmran"]').doesNotExist();
+
+        assert.ok(
+            getContentsStub.calledOnceWithExactly(),
+            'BinderHub retrieves Dockerfile data',
+        );
+        assert.ok(
+            ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser?include_stopped_servers=1', null),
+            'BinderHub calls JupyterHub REST API',
+        );
+        assert.dom('[data-test-package-editor="conda"] button[data-test-package-edit-item]').doesNotExist();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item]').doesNotExist();
+
+        await click('[data-test-package-editor="pip"] [data-test-package-add]');
+
+        assert.dom('[data-test-package-editor="pip"] input[name="package_name"]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-item-confirm]').exists();
+        await fillIn('[data-test-package-editor="pip"] input[name="package_name"]', 'testpackage');
+        await click('[data-test-package-editor="pip"] button[data-test-package-item-confirm]');
+
+        assert.equal(
+            updateContentsStub.getCall(0).args[0],
+            '# rdm-binderhub:hash:b5593825f5c1fca1627623cc5870ba0a\nFROM jupyter/scipy-notebook\n\nUSER root\n'
+                + 'RUN pip install -U --no-cache-dir \\\n\t\ttestpackage \n\nUSER $NB_USER\n\n'
+                + 'COPY --chown=$NB_UID:$NB_GID . .\n',
+        );
+
+        assert.dom('[data-test-package-editor="conda"] button[data-test-package-edit-item]').doesNotExist();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item]').exists();
+
+        getContentsStub.resetHistory();
+        updateContentsStub.resetHistory();
+
+        await click('[data-test-package-editor="pip"] [data-test-package-add]');
+
+        assert.dom('[data-test-package-editor="pip"] input[name="package_name"]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-item-confirm]').exists();
+        await fillIn('[data-test-package-editor="pip"] input[name="package_name"]', 'testpackage2');
+        await fillIn('[data-test-package-editor="pip"] input[name="package_version"]', '2.0.0');
+        await click('[data-test-package-editor="pip"] button[data-test-package-item-confirm]');
+
+        assert.equal(
+            updateContentsStub.getCall(0).args[0],
+            '# rdm-binderhub:hash:a45a5cbb263fad90f6a564cd978b7256\nFROM jupyter/scipy-notebook\n\n'
+                + 'USER root\nRUN pip install -U --no-cache-dir \\\n\t\ttestpackage  \\\n\t\ttestpackage2==2.0.0 \n\n'
+                + 'USER $NB_USER\n\nCOPY --chown=$NB_UID:$NB_GID . .\n',
+        );
+
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item="0"]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item="1"]').exists();
+
+        getContentsStub.resetHistory();
+        updateContentsStub.resetHistory();
+
+        await click('[data-test-package-editor="pip"] button[data-test-package-edit-item="0"]');
+        assert.dom('[data-test-package-editor="pip"] input[name="package_name"]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-item-confirm]').exists();
+        await fillIn('[data-test-package-editor="pip"] input[name="package_version"]', '1.0.0');
+        await click('[data-test-package-editor="pip"] button[data-test-package-item-confirm]');
+
+        assert.equal(
+            updateContentsStub.getCall(0).args[0],
+            '# rdm-binderhub:hash:d0a42ba50b7cd64445ea6f40ab5e5a40\nFROM jupyter/scipy-notebook\n\nUSER root\n'
+                + 'RUN pip install -U --no-cache-dir \\\n\t\ttestpackage==1.0.0  \\\n\t\ttestpackage2==2.0.0 \n\n'
+                + 'USER $NB_USER\n\nCOPY --chown=$NB_UID:$NB_GID . .\n',
+        );
+
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item="0"]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item="1"]').exists();
+
+        getContentsStub.resetHistory();
+        updateContentsStub.resetHistory();
+
+        await click('[data-test-package-editor="pip"] button[data-test-package-delete-item="0"]');
+
+        assert.equal(
+            updateContentsStub.getCall(0).args[0],
+            '# rdm-binderhub:hash:42326367829418c69a54417da69946ad\nFROM jupyter/scipy-notebook\n\nUSER root\n'
+                + 'RUN pip install -U --no-cache-dir \\\n\t\ttestpackage2==2.0.0 \n\nUSER $NB_USER\n\n'
+                + 'COPY --chown=$NB_UID:$NB_GID . .\n',
+        );
+
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item="0"]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item="1"]').doesNotExist();
+
+        sandbox.restore();
+    });
+
+    test('already configured, pip on repo2docker', async assert => {
+        const node = server.create('node', {
+            id: 'i9bri',
+            currentUserPermissions: [Permission.Write],
+        });
+        server.create('binderhub-config', {
+            id: node.id,
+            binderhubs: [{
+                default: true,
+                url: 'http://localhost:8585/',
+                authorize_url: 'http://localhost/authorize',
+                token: {
+                    access_token: 'TESTBHTOKEN',
+                    token_type: 'Bearer',
+                    expires_at: null,
+                },
+                jupyterhub_url: 'http://localhost:30123/',
+            }],
+            jupyterhubs: [{
+                url: 'http://localhost:30123/',
+                api_url: 'http://localhost:30123/hub/api/',
+                authorize_url: 'http://localhost/authorize',
+                token: {
+                    user: 'testuser',
+                    access_token: 'TESTJHTOKEN',
+                    token_type: 'Bearer',
+                    expires_at: null,
+                },
+            }],
+            node_binderhubs: [
+                {
+                    binderhub_url: 'http://localhost:8585/',
+                    jupyterhub_url: 'http://localhost:30123/',
+                },
+            ],
+            user_binderhubs: [],
+            deployment: {
+                images: [
+                    {
+                        url: '#repo2docker#r-base',
+                        name: 'Test Repo2Docker',
+                        description: 'dummy description',
+                        packages: ['conda', 'pip', 'rmran'],
+                    },
+                ],
+            },
+            launcher: {
+                endpoints: [
+                    {
+                        id: 'fake',
+                        name: 'Fake',
+                        path: 'Fake',
+                    },
+                ],
+            },
+        });
+        const osfstorage = server.create('file-provider',
+            { node, name: 'osfstorage' });
+        const binderFolder = server.create('file', { target: node }, 'asFolder');
+        binderFolder.update({
+            name: '.binder',
+        });
+        server.create('file',
+            {
+                target: node,
+                name: 'a',
+                dateModified: new Date(2019, 3, 3),
+                parentFolder: binderFolder,
+            });
+        server.create('file',
+            {
+                target: node,
+                name: 'environment.yml',
+                dateModified: new Date(2019, 2, 2),
+                parentFolder: binderFolder,
+            });
+        osfstorage.rootFolder.update({
+            files: [binderFolder],
+        });
+        const sandbox = sinon.createSandbox();
+        const ajaxStub = sandbox.stub(BinderHubConfigModel.prototype, 'jupyterhubAPIAJAX');
+        ajaxStub.resolves({
+            kind: 'user',
+            name: 'testuser',
+            servers: {},
+        });
+        const getContentsStub = sandbox.stub(FileModel.prototype, 'getContents');
+        const toStringStub = sinon.stub();
+        toStringStub.returns('# rdm-binderhub:hash:bb2a9dd68272d5f92e93acfbcfbbd267\n'
+            + 'name: "#repo2docker#r-base"\ndependencies:\n- r-base\n');
+        getContentsStub.resolves({ toString: toStringStub });
+        const updateContentsStub = sandbox.stub(FileModel.prototype, 'updateContents');
+        const url = `/${node.id}/binderhub`;
+
+        await visit(url);
+        assert.equal(currentURL(), url, `We are on ${url}`);
+        assert.equal(currentRouteName(), 'guid-node.binderhub', 'We are at guid-node.binderhub');
+        await percySnapshot(assert);
+        assert.dom('[data-test-servers-header]').exists();
+        assert.dom('[data-test-binderhub-header]').exists();
+        assert.dom('[data-test-jupyterhub-selection-option]').exists({ count: 1 });
+        assert.dom('[data-test-binderhub-launch]').exists();
+        assert.dom('[data-test-image-change="#repo2docker#r-base"]').exists();
+        assert.dom('[data-test-image-selected="#repo2docker#r-base"]').exists();
+        assert.dom('[data-test-image-selection]').doesNotExist();
+        assert.dom('[data-test-package-editor="apt"]').exists();
+        assert.dom('[data-test-package-editor="conda"]').exists();
+        assert.dom('[data-test-package-editor="pip"]').exists();
+        assert.dom('[data-test-package-editor="rmran"]').exists();
+
+        assert.ok(
+            getContentsStub.calledOnceWithExactly(),
+            'BinderHub retrieves environment.yml data',
+        );
+        assert.ok(
+            ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser?include_stopped_servers=1', null),
+            'BinderHub calls JupyterHub REST API',
+        );
+        assert.dom('[data-test-package-editor="conda"] button[data-test-package-edit-item]').doesNotExist();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item]').doesNotExist();
+
+        await click('[data-test-package-editor="pip"] [data-test-package-add]');
+
+        assert.dom('[data-test-package-editor="pip"] input[name="package_name"]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-item-confirm]').exists();
+        await fillIn('[data-test-package-editor="pip"] input[name="package_name"]', 'testpackage');
+        await click('[data-test-package-editor="pip"] button[data-test-package-item-confirm]');
+
+        assert.equal(
+            updateContentsStub.getCall(0).args[0],
+            '# rdm-binderhub:hash:b093e8ad8a6f8545bffc2d2d2b0ea511\nname: "#repo2docker#r-base"\ndependencies:\n'
+                + '- r-base\n- pip\n- pip:\n  - testpackage\n',
+        );
+
+        assert.dom('[data-test-package-editor="conda"] button[data-test-package-edit-item]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item]').exists();
+
+        getContentsStub.resetHistory();
+        updateContentsStub.resetHistory();
+
+        await click('[data-test-package-editor="pip"] [data-test-package-add]');
+
+        assert.dom('[data-test-package-editor="pip"] input[name="package_name"]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-item-confirm]').exists();
+        await fillIn('[data-test-package-editor="pip"] input[name="package_name"]', 'testpackage2');
+        await fillIn('[data-test-package-editor="pip"] input[name="package_version"]', '2.0.0');
+        await click('[data-test-package-editor="pip"] button[data-test-package-item-confirm]');
+
+        assert.equal(
+            updateContentsStub.getCall(0).args[0],
+            '# rdm-binderhub:hash:8945f069096ac7de0f2fc2b520c03c7e\nname: "#repo2docker#r-base"\ndependencies:\n'
+                + '- pip\n- r-base\n- pip:\n  - testpackage\n  - testpackage2==2.0.0\n',
+        );
+
+        assert.dom('[data-test-package-editor="conda"] button[data-test-package-edit-item]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item="0"]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item="1"]').exists();
+
+        getContentsStub.resetHistory();
+        updateContentsStub.resetHistory();
+
+        await click('[data-test-package-editor="pip"] button[data-test-package-edit-item="0"]');
+        assert.dom('[data-test-package-editor="pip"] input[name="package_name"]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-item-confirm]').exists();
+        await fillIn('[data-test-package-editor="pip"] input[name="package_version"]', '1.0.0');
+        await click('[data-test-package-editor="pip"] button[data-test-package-item-confirm]');
+
+        assert.equal(
+            updateContentsStub.getCall(0).args[0],
+            '# rdm-binderhub:hash:0373e4c7c00ca8ca191fa56b757fd1c0\nname: "#repo2docker#r-base"\ndependencies:\n'
+                + '- pip\n- r-base\n- pip:\n  - testpackage==1.0.0\n  - testpackage2==2.0.0\n',
+        );
+
+        assert.dom('[data-test-package-editor="conda"] button[data-test-package-edit-item]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item="0"]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item="1"]').exists();
+
+        getContentsStub.resetHistory();
+        updateContentsStub.resetHistory();
+
+        await click('[data-test-package-editor="pip"] button[data-test-package-delete-item="0"]');
+
+        assert.equal(
+            updateContentsStub.getCall(0).args[0],
+            '# rdm-binderhub:hash:1195309e970cd09c0353cc3bb8f3f532\nname: "#repo2docker#r-base"\ndependencies:\n'
+                + '- pip\n- r-base\n- pip:\n  - testpackage2==2.0.0\n',
+        );
+
+        assert.dom('[data-test-package-editor="conda"] button[data-test-package-edit-item]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item="0"]').exists();
+        assert.dom('[data-test-package-editor="pip"] button[data-test-package-edit-item="1"]').doesNotExist();
+
+        sandbox.restore();
+    });
+
+    test('reached server limit', async assert => {
+        const node = server.create('node', {
+            id: 'i9bri',
+            currentUserPermissions: [Permission.Write],
+        });
+        server.create('binderhub-config', {
+            id: node.id,
+            binderhubs: [{
+                default: true,
+                url: 'http://localhost:8585/',
+                authorize_url: 'http://localhost/authorize',
+                token: {
+                    access_token: 'TESTBHTOKEN',
+                    token_type: 'Bearer',
+                    expires_at: null,
+                },
+                jupyterhub_url: 'http://localhost:30123/',
+            }],
+            jupyterhubs: [{
+                url: 'http://localhost:30123/',
+                api_url: 'http://localhost:30123/hub/api/',
+                authorize_url: 'http://localhost/authorize',
+                token: {
+                    user: 'testuser',
+                    access_token: 'TESTJHTOKEN',
+                    token_type: 'Bearer',
+                    expires_at: null,
+                },
+            }],
+            node_binderhubs: [
+                {
+                    binderhub_url: 'http://localhost:8585/',
+                    jupyterhub_url: 'http://localhost:30123/',
+                },
+                {
+                    binderhub_url: 'http://192.168.168.167:8585/',
+                    jupyterhub_url: 'http://192.168.168.167:30123/',
+                },
+            ],
+            user_binderhubs: [],
+            deployment: {
+                images: [
+                    {
+                        url: 'jupyter/scipy-notebook',
+                        name: 'Test Image',
+                        description: 'dummy description',
+                        packages: ['conda'],
+                    },
+                ],
+            },
+            launcher: {
+                endpoints: [
+                    {
+                        id: 'fake',
+                        name: 'Fake',
+                        path: 'Fake',
+                    },
+                ],
+            },
+        });
+        const osfstorage = server.create('file-provider',
+            { node, name: 'osfstorage' });
+        const binderFolder = server.create('file', { target: node }, 'asFolder');
+        binderFolder.update({
+            name: '.binder',
+        });
+        server.create('file',
+            {
+                target: node,
+                name: 'a',
+                dateModified: new Date(2019, 3, 3),
+                parentFolder: binderFolder,
+            });
+        server.create('file',
+            {
+                target: node,
+                name: 'Dockerfile',
+                dateModified: new Date(2019, 2, 2),
+                parentFolder: binderFolder,
+            });
+        osfstorage.rootFolder.update({
+            files: [binderFolder],
+        });
+        const sandbox = sinon.createSandbox();
+        const ajaxStub = sandbox.stub(BinderHubConfigModel.prototype, 'jupyterhubAPIAJAX');
+        ajaxStub.resolves({
+            kind: 'user',
+            name: 'testuser',
+            servers: {
+                '': {
+                    name: '',
+                },
+                'server-1': {
+                    name: 'server-1',
+                },
+                'i9bri-osfstorage-1': {
+                    name: 'i9bri-osfstorage-1',
+                },
+            },
+        });
+        const getContentsStub = sandbox.stub(FileModel.prototype, 'getContents');
+        const toStringStub = sinon.stub();
+        toStringStub.returns('# rdm-binderhub:hash:7c5b3a3d0a63ffd19147fd8c5e52d9a0\nFROM jupyter/scipy-notebook\n');
+        getContentsStub.resolves({ toString: toStringStub });
+        const url = `/${node.id}/binderhub`;
+
+        await visit(url);
+        assert.equal(currentURL(), url, `We are on ${url}`);
+        assert.equal(currentRouteName(), 'guid-node.binderhub', 'We are at guid-node.binderhub');
+        await percySnapshot(assert);
+        assert.dom('[data-test-servers-header]').exists();
+        assert.dom('[data-test-binderhub-header]').exists();
+        assert.dom('[data-test-jupyterhub-selection-option]').exists({ count: 2 });
+        assert.dom('[data-test-binderhub-launch]').exists();
+
+        assert.dom('[data-test-server-list-item]').exists();
+        assert.dom('[data-test-max-servers-exceeded]').doesNotExist();
+
+        assert.ok(
+            ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser?include_stopped_servers=1', null),
+            'BinderHub calls JupyterHub REST API',
+        );
+
+        ajaxStub.resetHistory();
+
+        ajaxStub.resolves({
+            kind: 'user',
+            name: 'testuser',
+            servers: {
+                '': {
+                    name: '',
+                },
+                'server-1': {
+                    name: 'server-1',
+                },
+                'i9bri-osfstorage-1': {
+                    name: 'i9bri-osfstorage-1',
+                },
+            },
+            named_server_limit: 3,
+        });
+
+        await click('[data-test-server-refresh-button]');
+
+        assert.dom('[data-test-server-list-item]').exists();
+        assert.dom('[data-test-max-servers-exceeded]').doesNotExist();
+
+        assert.ok(
+            ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser?include_stopped_servers=1', null),
+            'BinderHub calls JupyterHub REST API',
+        );
+
+        ajaxStub.resetHistory();
+
+        ajaxStub.resolves({
+            kind: 'user',
+            name: 'testuser',
+            servers: {
+                '': {
+                    name: '',
+                },
+                'server-1': {
+                    name: 'server-1',
+                },
+                'i9bri-osfstorage-1': {
+                    name: 'i9bri-osfstorage-1',
+                },
+                'i9bri-osfstorage-2': {
+                    name: 'i9bri-osfstorage-2',
+                },
+            },
+            named_server_limit: 3,
+        });
+
+        await click('[data-test-server-refresh-button]');
+
+        assert.dom('[data-test-server-list-item]').exists();
+        assert.dom('[data-test-max-servers-exceeded]').exists();
+
+        assert.ok(
+            ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser?include_stopped_servers=1', null),
             'BinderHub calls JupyterHub REST API',
         );
 


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: GRDM-35282, GRDM-31366, GRDM-31368
- Feature flag: n/a

## Purpose

BinderHubアドオンのバグ修正及びJupyterHub機能拡張に追従する変更です。

## Summary of Changes

- [GRDM-35282] 基本イメージ「Python 3.9 + R 4.1.3」の場合に「pip」に追加したソフトウェアがインストールされない(バグ修正)
- [GRDM-31366] JupyterHub API 非activeなServerが取得できない (JupyterHub機能拡張)
- [GRDM-31368] 起動可能な最大サーバー数をJupyterHub APIで返す (JupyterHub機能拡張)

## Side Effects

None

## QA Notes

None