### PR TITLE
Fix to display correct modal when failed new project creation

### DIFF
--- a/lib/osf-components/addon/components/new-project-modal/component.ts
+++ b/lib/osf-components/addon/components/new-project-modal/component.ts
@@ -141,6 +141,7 @@ export default class NewProjectModal extends Component {
                 const errorMessage = this.intl.t('new_project.could_not_create_project');
                 captureException(e, { errorMessage });
                 this.toast.error(getApiErrorMessage(e), errorMessage);
+                throw e;
             }
 
             this.afterProjectCreated(node);


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: GRDM-33518
- Feature flag: n/a

## Purpose
Fix to display correct modal when failed new project creation
<!-- Describe the purpose of your changes. -->

## Summary of Changes
Fix to display correct modal when failed new project creation
<!-- Briefly describe or list your changes. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
