### PR TITLE
[GRDM-35861] JPCOARスキーマ2.0への対応改修

### DIFF
--- a/app/packages/registration-schema/get-schema-block-group.ts
+++ b/app/packages/registration-schema/get-schema-block-group.ts
@@ -57,6 +57,7 @@ export function getSchemaBlockGroups(blocks: SchemaBlock[] | undefined) {
             case 'file-url-input':
             case 'file-institution-ja-input':
             case 'file-institution-en-input':
+            case 'file-institution-id-input':
 
                 assert('input block with no registrationResponseKey!', !isEmpty(block.registrationResponseKey));
                 assert('question with multiple input blocks!', !schemaBlockGroup.inputBlock);

--- a/app/packages/registration-schema/get-schema-block-group.ts
+++ b/app/packages/registration-schema/get-schema-block-group.ts
@@ -39,6 +39,7 @@ export function getSchemaBlockGroups(blocks: SchemaBlock[] | undefined) {
             case 'single-select-input':
             case 'multi-select-input':
             case 'japan-grant-number-input':
+            case 'funding-stream-code-input':
             case 'jgn-program-name-ja-input':
             case 'jgn-program-name-en-input':
             case 'e-rad-award-funder-input':

--- a/app/packages/registration-schema/schema-block.ts
+++ b/app/packages/registration-schema/schema-block.ts
@@ -30,7 +30,8 @@ export type SchemaBlockType =
     'file-creators-input' |
     'file-url-input' |
     'file-institution-ja-input' |
-    'file-institution-en-input';
+    'file-institution-en-input' |
+    'file-institution-id-input';
 
 export interface SchemaBlock {
     id?: string;

--- a/app/packages/registration-schema/schema-block.ts
+++ b/app/packages/registration-schema/schema-block.ts
@@ -13,6 +13,7 @@ export type SchemaBlockType =
     'select-input-option' |
     'select-other-option' |
     'japan-grant-number-input' |
+    'funding-stream-code-input' |
     'jgn-program-name-ja-input' |
     'jgn-program-name-en-input' |
     'e-rad-award-funder-input' |

--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -59,7 +59,7 @@ export function buildValidation(groups: SchemaBlockGroup[], node?: NodeModel) {
                 const key = (group.registrationResponseKey || '').substr('__responseKey_'.length);
                 validationForResponse.push(
                     validateFormat({
-                        allowBlank: false,
+                        allowBlank: !inputBlock.required,
                         regex: new RegExp(inputBlock.pattern),
                         type: `invalid_format_${key}`,
                     }),

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
@@ -72,6 +72,17 @@
         metadataNodeErad=@metadataNodeErad
         draftManager=@draftManager
     )
+    funding-stream-code-input=(
+        component
+        'registries/schema-block-renderer/editable/rdm/funding-stream-code-input'
+        changeset=@changeset
+        metadataChangeset=@metadataChangeset
+        onInput=@onInput
+        onMetadataInput=@onMetadataInput
+        node=@node
+        metadataNodeErad=@metadataNodeErad
+        draftManager=@draftManager
+    )
     jgn-program-name-ja-input=(
         component
         'registries/schema-block-renderer/editable/rdm/jgn-program-name-ja-input'

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/styles.scss
@@ -19,6 +19,27 @@
     height: 35px;
 }
 
+.file-metadata-input-files .file-metadata-path {
+    max-width: 250px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.file-metadata-input-files .file-metadata-title {
+    max-width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.file-metadata-input-files .file-metadata-manager {
+    max-width: 50px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .file-metadata-input-edit-button {
     padding: 0 !important;
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/template.hbs
@@ -53,7 +53,7 @@
                                 {{/if}}
                             </td>
                             <td class='col-md-4'>
-                                <p style={{fileEntry.style}}>
+                                <p style={{fileEntry.style}} local-class='file-metadata-path'>
                                     {{#if fileEntry.folder}}
                                         {{#if fileEntry.folderExpanded}}
                                             <button
@@ -81,7 +81,7 @@
                                     {{fileEntry.lastPart}}
                                 </p>
                             </td>
-                            <td class='col-md-3'>
+                            <td class='col-md-3' local-class='file-metadata-title'>
                                 {{#if fileEntry.url}}
                                     <a href='{{fileEntry.url}}' target='_blank' rel='noopener'>
                                         {{fileEntry.title}}
@@ -90,7 +90,7 @@
                                     {{fileEntry.title}}
                                 {{/if}}
                             </td>
-                            <td class='col-md-3'>
+                            <td class='col-md-3' local-class='file-metadata-manager'>
                                 {{#if fileEntry.manager}}
                                     {{fileEntry.manager}}
                                 {{else}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/funding-stream-code-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/funding-stream-code-input/component.ts
@@ -1,0 +1,23 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+
+import { alias } from '@ember/object/computed';
+import { ChangesetDef } from 'ember-changeset/types';
+import { layout } from 'ember-osf-web/decorators/component';
+import DraftRegistrationManager from 'registries/drafts/draft/draft-registration-manager';
+import styles from './styles';
+import template from './template';
+
+@layout(template, styles)
+@tagName('')
+export default class FundingStreamCodeInput extends Component {
+    // Required param
+    changeset!: ChangesetDef;
+    metadataChangeset!: ChangesetDef;
+    draftManager!: DraftRegistrationManager;
+
+    @alias('schemaBlock.registrationResponseKey')
+    valuePath!: string;
+    onInput!: () => void;
+    onMetadataInput!: () => void;
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/funding-stream-code-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/funding-stream-code-input/styles.scss
@@ -1,0 +1,8 @@
+.schema-block-input {
+    :global(input) {
+        height: 40px;
+        color: $color-text-gray-blue;
+        border-radius: 2px;
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/funding-stream-code-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/funding-stream-code-input/template.hbs
@@ -1,0 +1,16 @@
+<Registries::SchemaBlockRenderer::Editable::Base @helpText={{this.schemaBlock.helpText}}>
+    <FormControls
+        @changeset={{@changeset}}
+        @disabled={{@disabled}}
+        @shouldShowMessages={{@shouldShowMessages}}
+        ...attributes as |form|
+    >
+        <form.text
+            data-test-funding-stream-code-input
+            local-class='schema-block-input'
+            @uniqueID={{@uniqueID}}
+            @valuePath={{@schemaBlock.registrationResponseKey}}
+            @placeholder=' '
+        />
+    </FormControls>
+</Registries::SchemaBlockRenderer::Editable::Base>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/japan-grant-number-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/japan-grant-number-input/component.ts
@@ -55,6 +55,12 @@ export default class JapanGrantNumberInput extends Component {
             kadaiId = eradRecord.japan_grant_number;
             this.updateCode('e-rad-award-funder-input', eradRecord.haibunkikan_cd);
             this.updateCode('e-rad-award-field-input', eradRecord.bunya_cd);
+            if (eradRecord.funding_stream_code) {
+                const key = this.getResponseKeyByBlockType('funding-stream-code-input');
+                if (key) {
+                    this.changeset.set(key, eradRecord.funding_stream_code);
+                }
+            }
             if (eradRecord.program_name_ja) {
                 const key = this.getResponseKeyByBlockType('jgn-program-name-ja-input');
                 if (key) {

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
@@ -62,6 +62,12 @@
         registrationResponses=@registrationResponses
         changeset=@changeset
     )
+    funding-stream-code-input=(
+        component
+        'registries/schema-block-renderer/read-only/response'
+        registrationResponses=@registrationResponses
+        changeset=@changeset
+    )
     jgn-program-name-ja-input=(
         component
         'registries/schema-block-renderer/read-only/response'

--- a/lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/funding-stream-code-input/component.js
+++ b/lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/funding-stream-code-input/component.js
@@ -1,0 +1,2 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/editable/rdm/funding-stream-code-input/component';

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -537,6 +537,7 @@ validationErrors:
     new_folder_name: 'Folder name must not be blank.'
     year_format: 'Please specify a valid year.'
     invalid_format_funder: 'Please use single-byte alphanumeric characters.'
+    invalid_format_funding-stream-code: 'Please enter up to 5 single-byte alphanumeric characters.'
 validated_input_form:
     discard_changes: 'Discard changes'
 node_navbar:

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -537,6 +537,7 @@ validationErrors:
     new_folder_name: 'Folder name must not be blank.'
     year_format: 'Please specify a valid year.'
     invalid_format_funder: '半角英数字で入力してください。'
+    invalid_format_funding-stream-code: '5文字以内の半角英数字で入力してください。'
 validated_input_form:
     discard_changes: 変更を破棄
 node_navbar:


### PR DESCRIPTION
あわせて https://github.com/RCOSDP/RDM-osf.io/pull/398 のMergeもお願いします。

## Purpose

Metadata アドオンにおいてJPCOARスキーマ2.0への対応改修をしました。

## Changes

- [GRDM-35861] 
  - 「データ管理機関コード」 に対応しました。
  - 「体系的番号におけるプログラム情報コード」に対応しました。補完も対応しました。
  - メタデータ登録画面のファイルメタデータ一覧のUIを修正しました。


## QA Notes
None

## Documentation
None

## Side Effects
None

## Ticket
GRDM-35861
