### PR TITLE
[GRDM-35917] BinderHubアドオンが「拡張ストレージマウント方式」機関ストレージの機関にてエラーで利用できない

### DIFF
--- a/app/guid-node/binderhub/-components/jupyter-servers-list/component.ts
+++ b/app/guid-node/binderhub/-components/jupyter-servers-list/component.ts
@@ -447,7 +447,7 @@ export default class JupyterServersList extends Component {
         if (!this.node) {
             return false;
         }
-        const m = server.name.match(/^(.+)-osfstorage-(.+)$/);
+        const m = server.name.match(/^(.+)-([a-z0-9]+)-(.+)$/);
         if (!m) {
             return false;
         }

--- a/app/guid-node/binderhub/controller.ts
+++ b/app/guid-node/binderhub/controller.ts
@@ -204,7 +204,16 @@ export default class GuidNodeBinderHub extends Controller {
         if (instProviders.length === 0) {
             throw new EmberError('No default storages');
         }
-        // TBD sort storages by name
+        // Sort storages by name
+        instProviders.sort((a, b) => {
+            if (a.name < b.name) {
+                return -1;
+            }
+            if (a.name > b.name) {
+                return 1;
+            }
+            return 0;
+        });
         return instProviders[0];
     }
 
@@ -301,8 +310,11 @@ export default class GuidNodeBinderHub extends Controller {
         if (!this.node) {
             throw new EmberError('Illegal config');
         }
+        if (!this.configFolder) {
+            throw new EmberError('Illegal config');
+        }
         const nodeUrl = this.node.links.html as string;
-        const storageUrl = addPathSegment(nodeUrl, 'osfstorage');
+        const storageUrl = addPathSegment(nodeUrl, this.configFolder.provider);
         const encodedNodeUrl = encodeURIComponent(storageUrl);
         return {
             providerPrefix: 'rdm',

--- a/app/guid-node/binderhub/controller.ts
+++ b/app/guid-node/binderhub/controller.ts
@@ -178,7 +178,7 @@ export default class GuidNodeBinderHub extends Controller {
             if (!link) {
                 throw new EmberError('Illegal state');
             }
-            await this.currentUser.authenticatedAJAX({
+            await this.wbAuthenticatedAJAX({
                 url: `${getHref(link)}&name=.binder`,
                 type: 'PUT',
                 xhrFields: { withCredentials: true },
@@ -391,6 +391,11 @@ export default class GuidNodeBinderHub extends Controller {
         }
         ourl.search = `?${osearch.toString()}`;
         return ourl.href;
+    }
+
+    async wbAuthenticatedAJAX(ajaxOptions: JQuery.AjaxSettings) {
+        const r = await this.currentUser.authenticatedAJAX(ajaxOptions);
+        return r;
     }
 }
 

--- a/app/models/file-provider.ts
+++ b/app/models/file-provider.ts
@@ -27,6 +27,7 @@ export default class FileProviderModel extends BaseFileItem {
     @attr('fixstring') name!: string;
     @attr('string') path!: string;
     @attr('fixstring') provider!: string;
+    @attr('boolean') forInstitutions?: boolean;
 
     @belongsTo('file')
     rootFolder!: DS.PromiseObject<FileModel> & FileModel;

--- a/app/utils/waterbutler/base.ts
+++ b/app/utils/waterbutler/base.ts
@@ -1,6 +1,8 @@
 import CurrentUser from 'ember-osf-web/services/current-user';
 
 export interface WaterButlerFile {
+    provider: string;
+
     name: string;
 
     path: string;
@@ -58,6 +60,10 @@ export abstract class AbstractFile implements WaterButlerFile {
     constructor(currentUser: CurrentUser, metadata: Metadata) {
         this.currentUser = currentUser;
         this.metadata = metadata;
+    }
+
+    get provider() {
+        return this.metadata.provider;
     }
 
     get name() {

--- a/app/utils/waterbutler/base.ts
+++ b/app/utils/waterbutler/base.ts
@@ -1,0 +1,153 @@
+import CurrentUser from 'ember-osf-web/services/current-user';
+
+export interface WaterButlerFile {
+    name: string;
+
+    path: string;
+
+    files: Promise<WaterButlerFile[]> | WaterButlerFile[];
+
+    htmlURL: string | undefined;
+
+    reload: () => Promise<WaterButlerFile>;
+
+    getContents: () => Promise<object>;
+
+    updateContents: (data: string) => Promise<void>;
+
+    createFile: (name: string, data: string) => Promise<void>;
+
+    delete: () => Promise<void>;
+}
+
+export interface Metadata {
+    kind: string | undefined;
+
+    name: string;
+
+    path: string;
+
+    provider: string;
+}
+
+export interface FilesResponseLinks {
+    move?: string;
+
+    upload?: string;
+
+    delete?: string;
+}
+
+export interface FilesResponse {
+    type: string;
+
+    id: string;
+
+    attributes: Metadata;
+
+    links: FilesResponseLinks;
+}
+
+export abstract class AbstractFile implements WaterButlerFile {
+    currentUser!: CurrentUser;
+
+    metadata: Metadata;
+
+    cachedContent: WaterButlerFile[] | null = null;
+
+    constructor(currentUser: CurrentUser, metadata: Metadata) {
+        this.currentUser = currentUser;
+        this.metadata = metadata;
+    }
+
+    get name() {
+        return this.metadata.name;
+    }
+
+    get path() {
+        return this.metadata.path;
+    }
+
+    abstract get filesURL(): string;
+
+    abstract get deleteURL(): string;
+
+    abstract get htmlURL(): string | undefined;
+
+    abstract get downloadURL(): string | undefined;
+
+    abstract get uploadURL(): string;
+
+    get isFile(): boolean {
+        return this.metadata.kind === 'file';
+    }
+
+    get files(): Promise<WaterButlerFile[]> | WaterButlerFile[] {
+        if (this.cachedContent) {
+            return this.cachedContent;
+        }
+        return this.loadFiles();
+    }
+
+    async loadFiles(): Promise<WaterButlerFile[]> {
+        const content = await this.currentUser.authenticatedAJAX({
+            url: this.filesURL,
+            type: 'GET',
+            xhrFields: { withCredentials: true },
+        });
+        const { data } = content;
+        if (!data) {
+            return [];
+        }
+        return (data as FilesResponse[]).map(file => this.wrap(file));
+    }
+
+    async delete(): Promise<void> {
+        await this.currentUser.authenticatedAJAX({
+            url: this.deleteURL,
+            type: 'DELETE',
+            xhrFields: { withCredentials: true },
+        });
+    }
+
+    async getContents(): Promise<object> {
+        if (this.isFile) {
+            return this.currentUser.authenticatedAJAX({
+                url: this.downloadURL,
+                type: 'GET',
+                data: {
+                    direct: true,
+                    mode: 'render',
+                },
+            });
+        }
+        throw Error('Can only get the contents of files.');
+    }
+
+    async updateContents(data: string): Promise<void> {
+        await this.currentUser.authenticatedAJAX({
+            url: this.uploadURL,
+            type: 'PUT',
+            xhrFields: { withCredentials: true },
+            data,
+        });
+        await this.reload();
+    }
+
+    async createFile(name: string, data: string): Promise<void> {
+        await this.currentUser.authenticatedAJAX({
+            url: `${this.uploadURL}?name=${name}`,
+            type: 'PUT',
+            xhrFields: { withCredentials: true },
+            data,
+        });
+        await this.reload();
+    }
+
+    async reload(): Promise<WaterButlerFile> {
+        this.cachedContent = null;
+        return this;
+    }
+
+    abstract wrap(file: FilesResponse): WaterButlerFile;
+}

--- a/app/utils/waterbutler/base.ts
+++ b/app/utils/waterbutler/base.ts
@@ -90,7 +90,7 @@ export abstract class AbstractFile implements WaterButlerFile {
     }
 
     async loadFiles(): Promise<WaterButlerFile[]> {
-        const content = await this.currentUser.authenticatedAJAX({
+        const content = await this.wbAuthenticatedAJAX({
             url: this.filesURL,
             type: 'GET',
             xhrFields: { withCredentials: true },
@@ -103,7 +103,7 @@ export abstract class AbstractFile implements WaterButlerFile {
     }
 
     async delete(): Promise<void> {
-        await this.currentUser.authenticatedAJAX({
+        await this.wbAuthenticatedAJAX({
             url: this.deleteURL,
             type: 'DELETE',
             xhrFields: { withCredentials: true },
@@ -112,7 +112,7 @@ export abstract class AbstractFile implements WaterButlerFile {
 
     async getContents(): Promise<object> {
         if (this.isFile) {
-            return this.currentUser.authenticatedAJAX({
+            return this.wbAuthenticatedAJAX({
                 url: this.downloadURL,
                 type: 'GET',
                 data: {
@@ -125,7 +125,7 @@ export abstract class AbstractFile implements WaterButlerFile {
     }
 
     async updateContents(data: string): Promise<void> {
-        await this.currentUser.authenticatedAJAX({
+        await this.wbAuthenticatedAJAX({
             url: this.uploadURL,
             type: 'PUT',
             xhrFields: { withCredentials: true },
@@ -135,7 +135,7 @@ export abstract class AbstractFile implements WaterButlerFile {
     }
 
     async createFile(name: string, data: string): Promise<void> {
-        await this.currentUser.authenticatedAJAX({
+        await this.wbAuthenticatedAJAX({
             url: `${this.uploadURL}?name=${name}`,
             type: 'PUT',
             xhrFields: { withCredentials: true },
@@ -150,4 +150,9 @@ export abstract class AbstractFile implements WaterButlerFile {
     }
 
     abstract wrap(file: FilesResponse): WaterButlerFile;
+
+    async wbAuthenticatedAJAX(ajaxOptions: JQuery.AjaxSettings) {
+        const r = await this.currentUser.authenticatedAJAX(ajaxOptions);
+        return r;
+    }
 }

--- a/app/utils/waterbutler/file.ts
+++ b/app/utils/waterbutler/file.ts
@@ -1,0 +1,38 @@
+import CurrentUser from 'ember-osf-web/services/current-user';
+import { AbstractFile, FilesResponse, WaterButlerFile } from './base';
+
+export default class DefaultWaterButlerFile extends AbstractFile {
+    file: FilesResponse;
+
+    constructor(currentUser: CurrentUser, file: FilesResponse) {
+        super(currentUser, file.attributes);
+        this.file = file;
+    }
+
+    get filesURL(): string {
+        return this.file.links.delete!;
+    }
+
+    get deleteURL(): string {
+        return this.file.links.delete!;
+    }
+
+    get uploadURL(): string {
+        return this.file.links.delete!;
+    }
+
+    get downloadURL(): string | undefined {
+        return this.file.links.delete!;
+    }
+
+    get htmlURL(): string | undefined {
+        return undefined;
+    }
+
+    wrap(file: FilesResponse): WaterButlerFile {
+        if (file.type !== 'files') {
+            throw new Error(`Unknown type: ${file.type}`);
+        }
+        return new DefaultWaterButlerFile(this.currentUser, file);
+    }
+}

--- a/app/utils/waterbutler/provider.ts
+++ b/app/utils/waterbutler/provider.ts
@@ -1,0 +1,52 @@
+import { FileProviderLinks } from 'ember-osf-web/models/file-provider';
+import CurrentUser from 'ember-osf-web/services/current-user';
+import getHref from 'ember-osf-web/utils/get-href';
+import { AbstractFile, FilesResponse, Metadata, WaterButlerFile } from './base';
+import DefaultWaterButlerFile from './file';
+
+export default class WaterButlerFileProvider extends AbstractFile implements WaterButlerFile {
+    links!: FileProviderLinks;
+
+    constructor(currentUser: CurrentUser, metadata: Metadata, links: FileProviderLinks) {
+        super(currentUser, metadata);
+        this.links = links;
+    }
+
+    get filesURL(): string {
+        const link = this.links.upload;
+        return getHref(link);
+    }
+
+    get deleteURL(): string {
+        const link = this.links.delete;
+        return getHref(link);
+    }
+
+    get uploadURL(): string {
+        const link = this.links.upload;
+        return getHref(link);
+    }
+
+    get downloadURL(): string | undefined {
+        const link = this.links.download;
+        if (!link) {
+            return undefined;
+        }
+        return getHref(link);
+    }
+
+    get htmlURL(): string | undefined {
+        const link = this.links.html;
+        if (!link) {
+            return undefined;
+        }
+        return getHref(link);
+    }
+
+    wrap(file: FilesResponse): WaterButlerFile {
+        if (file.type !== 'files') {
+            throw new Error(`Unknown type: ${file.type}`);
+        }
+        return new DefaultWaterButlerFile(this.currentUser, file);
+    }
+}

--- a/app/utils/waterbutler/wrap.ts
+++ b/app/utils/waterbutler/wrap.ts
@@ -1,0 +1,22 @@
+import FileProviderModel from 'ember-osf-web/models/file-provider';
+import CurrentUser from 'ember-osf-web/services/current-user';
+import { WaterButlerFile } from './base';
+import WaterButlerFileProvider from './provider';
+
+/**
+ * Wrapper to access WaterButler's file service using osf.io FileProviderModel.
+ *
+ * @param currentUser Current User service.
+ * @param provider FileProviderModel
+ * @returns WaterButlerFile
+ */
+export async function wrap(currentUser: CurrentUser, provider: FileProviderModel): Promise<WaterButlerFile> {
+    const { links } = provider;
+    const metadata = {
+        kind: provider.kind !== undefined ? provider.kind.toString() : undefined,
+        name: provider.name,
+        path: provider.path,
+        provider: provider.provider,
+    };
+    return new WaterButlerFileProvider(currentUser, metadata, links);
+}


### PR DESCRIPTION
- Ticket: GRDM-35917

## Purpose

BinderHubアドオンが「拡張ストレージマウント方式」機関ストレージの機関にてエラーで利用できない問題の修正。

## Summary of Changes

- [GRDM-35917] osfstorageがない場合の代替ストレージの選択処理を追加しました。https://github.com/RCOSDP/RDM-osf.io/pull/405 で追加される `for_institutions` プロパティを代替ストレージの選択に使用します。また、[osf.ioのFiles API](https://developer.osf.io/#tag/Files)をサポートせず、[WaterButler API](https://waterbutler.readthedocs.io/en/latest/api.html)のみをサポートするケースを考慮し、osf.io APIではなくWaterButler APIを使用してファイル情報を取得するよう修正しました。

## Side Effects

None

## QA Notes

統合テストは以下の3つのストレージにおいて、BinderHubアドオンとの連携が正常に動作するかという観点で実施しております。

- デフォルトストレージ
- 機関ストレージ(一括マウント方式): 例としてAmazon S3
- 機関ストレージ(アドオン方式): 例としてOneDrive for Office365
