### PR TITLE
[GRDM-37926] Fix label of R (MRAN)

### DIFF
--- a/app/guid-node/binderhub/-components/project-editor/template.hbs
+++ b/app/guid-node/binderhub/-components/project-editor/template.hbs
@@ -134,7 +134,7 @@
                         <GuidNode::Binderhub::-Components::PackageEditor
                             data-test-package-editor='rmran'
                             @node={{this.node}}
-                            @label='R (MRAN)'
+                            @label='R (CRAN)'
                             @packages={{this.rMranPackages}}
                             @onUpdate={{action this.rMranUpdated}}
                             @editing={{if (eq this.editingPackage 'rmran') 'editing'}}


### PR DESCRIPTION
- Ticket: GRDM-37926
- Feature flag: n/a

## Purpose

MRANのサービス終了(2023/7/1)にともない、これまでR(MRAN)に指定されていたパッケージは cran.ism.ac.jp から取得する形に変更します( https://github.com/RCOSDP/CS-repo2docker/pull/12 )。それに伴ってラベルをR(MRAN)からR(CRAN)に変更します。ロジックの変更はなく、表示上の変更のみです。

## Summary of Changes

- [GRDM-37926] ラベルの変更

## Side Effects

None

## QA Notes

None