### PR TITLE
[GRDM-36922] (rcos-release) メタデータアドオンにて file-title-input の対応 

### DIFF
--- a/app/packages/registration-schema/get-schema-block-group.ts
+++ b/app/packages/registration-schema/get-schema-block-group.ts
@@ -51,6 +51,7 @@ export function getSchemaBlockGroups(blocks: SchemaBlock[] | undefined) {
             case 'date-input':
             case 'file-capacity-input':
             case 'file-creators-input':
+            case 'file-title-input':
             case 'file-url-input':
             case 'file-institution-ja-input':
             case 'file-institution-en-input':

--- a/app/packages/registration-schema/schema-block.ts
+++ b/app/packages/registration-schema/schema-block.ts
@@ -25,6 +25,7 @@ export type SchemaBlockType =
     'date-input' |
     'file-capacity-input' |
     'file-creators-input' |
+    'file-title-input' |
     'file-url-input' |
     'file-institution-ja-input' |
     'file-institution-en-input';


### PR DESCRIPTION
## Purpose
メタデータアドオンにて file-title-input スキーマブロックに対応しました。

## Summary of Changes
file-title-input スキーマブロックへの対応のみ

## Side Effects
None

## QA Notes
None

## Ticket
GRDM-36922
