### PR TITLE
[GRDM-40853] 課題名(英語)の補完

### DIFF
--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/japan-grant-number-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/japan-grant-number-input/component.ts
@@ -75,11 +75,15 @@ export default class JapanGrantNumberInput extends Component {
             }
             this.changeset.set(
                 this.draftManager.getResponseKeyByBlockType('e-rad-award-title-ja-input'),
-                eradRecord.kadai_mei,
+                this.getLocalizedTextFrom(eradRecord.kadai_mei, 0),
+            );
+            this.changeset.set(
+                this.draftManager.getResponseKeyByBlockType('e-rad-award-title-en-input'),
+                this.getLocalizedTextFrom(eradRecord.kadai_mei, 1),
             );
             this.metadataChangeset.set(
                 'title',
-                `${eradRecord.kadai_mei}`,
+                `${this.getLocalizedTextFrom(eradRecord.kadai_mei, 0)}`,
             );
         } else {
             kadaiId = option;
@@ -87,6 +91,23 @@ export default class JapanGrantNumberInput extends Component {
         this.changeset.set(this.valuePath, kadaiId);
         this.onMetadataInput();
         this.onInput();
+    }
+
+    getLocalizedTextFrom(text: string, index: number) {
+        const pos = text.lastIndexOf('|');
+        if (pos === -1) {
+            if (index === 1) {
+                return '';
+            }
+            return text;
+        }
+        if (index === 0) {
+            return text.substring(0, pos);
+        }
+        if (index === 1) {
+            return text.substring(pos + 1);
+        }
+        throw new Error(`Invalid index: ${index}`);
     }
 
     getResponseKeyByBlockType(name: string) {


### PR DESCRIPTION
(RCOS環境向けのPRです。)

- Ticket: GRDM-40853
- Feature flag: n/a

## Purpose

メタデータ入力画面において、課題名(英語)の補完機能を提供します。

## Summary of Changes

- [GRDM-40853] 体系的番号の選択時に、氏名等と同様に、課題名を `日本語|英語` で表現されているものとみなして補完を行うように修正

## Side Effects

None

## QA Notes

None