### PR TITLE
[GRDM-40428] IQB-RIMSアドオンにて10個以上の組図ファイルアップロード時にアップロード漏れが生じる不具合の修正

### DIFF
--- a/app/guid-node/iqbrims/controller.ts
+++ b/app/guid-node/iqbrims/controller.ts
@@ -85,7 +85,7 @@ export default class GuidNodeIQBRIMS extends Controller {
 
     @task
     moveFilesInFolder = task(function *(this: GuidNodeIQBRIMS, folder: File) {
-        const files: [File] = yield folder.files;
+        const files: [File] = yield folder.loadAll('files');
         const path = `/${folder.name}/`;
         yield all(files.map(f => this.moveOnCurrentProjectTask.perform(f, 'iqbrims', path)));
     });
@@ -131,7 +131,7 @@ export default class GuidNodeIQBRIMS extends Controller {
         }
         const defaultStorage: File = yield defaultStorageProviders[0].get('rootFolder');
         this.set('defaultStorage', defaultStorage);
-        let storageFiles: [File] = yield defaultStorage.get('files');
+        let storageFiles: [File] = yield defaultStorage.loadAll('files');
         let files = storageFiles.filter(f => f.name === this.workingFolderName);
         if (files.length === 0) {
             yield this.createWorkingDirectory.perform(defaultStorageProviders[0]);

--- a/app/guid-node/iqbrims/file-browser.ts
+++ b/app/guid-node/iqbrims/file-browser.ts
@@ -167,7 +167,7 @@ export default class IQBRIMSFileBrowser extends EmberObject {
 
     @task
     prepareDefaultStorageFiles = task(function *(this: IQBRIMSFileBrowser, workingDirectory: File) {
-        let storageFiles: [File] = yield workingDirectory.get('files');
+        let storageFiles: [File] = yield workingDirectory.loadAll('files');
         let files = storageFiles.filter(f => f.name === this.folderName);
         if (files.length === 0) {
             yield this.createTargetDirectory.perform(workingDirectory);
@@ -177,7 +177,7 @@ export default class IQBRIMSFileBrowser extends EmberObject {
         }
         const targetDirectory = files[0];
         this.set('targetDirectory', targetDirectory);
-        const fileList: [File] = yield targetDirectory.get('files');
+        const fileList: [File] = yield targetDirectory.loadAll('files');
         const allFiles = fileList.filter(this.filterFiles);
         const indexFiles = fileList.filter(f => !this.filterFiles(f));
         this.set('indexFile', indexFiles.length > 0 ? indexFiles[0] : null);
@@ -208,7 +208,7 @@ export default class IQBRIMSFileBrowser extends EmberObject {
         const targetDirectory = files[0];
         this.set('gdTargetDirectory', targetDirectory);
         this.set('gdLoading', false);
-        const fileList: [File] = yield targetDirectory.get('files');
+        const fileList: [File] = yield targetDirectory.loadAll('files');
         const allFiles = fileList.filter(this.filterFiles);
         this.set('gdAllFiles', allFiles);
     });

--- a/tests/acceptance/guid-node/iqbrims-test.ts
+++ b/tests/acceptance/guid-node/iqbrims-test.ts
@@ -97,8 +97,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({
@@ -156,8 +156,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({
@@ -217,8 +217,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({
@@ -278,8 +278,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({
@@ -339,8 +339,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({
@@ -398,8 +398,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({
@@ -457,8 +457,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({


### PR DESCRIPTION
※ #100 と同じ内容で develop ブランチ向けにしたものです。

- Ticket: GRDM-40428
- Feature flag: n/a

## Purpose

IQB-RIMSアドオンにて10個以上の組図ファイルアップロード時にアップロード漏れが生じる不具合を修正しました。

## Summary of Changes

- アップロード時のファイル読み込みで全てのファイルを読み込むよう修正
- アップロード前・後で全てのファイルが表示されるよう修正

## Side Effects

None

## QA Notes

None