### PR TITLE
[GRDM-40428] RCOS環境テスト修正: IQB-RIMSアドオンにて10個以上の組図ファイルアップロード時にアップロード漏れが生じる不具合の修正

### DIFF
--- a/tests/acceptance/guid-node/iqbrims-test.ts
+++ b/tests/acceptance/guid-node/iqbrims-test.ts
@@ -97,8 +97,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({
@@ -156,8 +156,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({
@@ -217,8 +217,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({
@@ -278,8 +278,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({
@@ -339,8 +339,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({
@@ -398,8 +398,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({
@@ -457,8 +457,8 @@ module('Acceptance | guid-node/iqbrims', hooks => {
                     name,
                     dateModified: new Date(2022, 6, 17),
                     parentFolder: tempFolder,
-                    files: [],
                 },
+                'asFolder',
             );
         }
         osfstorage.rootFolder.update({


### PR DESCRIPTION

<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: GRDM-40428
- Feature flag: n/a

## Purpose

IQB-RIMS loadAllを用いる修正 https://github.com/RCOSDP/RDM-ember-osf-web/pull/100 において、Travis CIが失敗する問題の修正です。

## Summary of Changes

- IQB-RIMSのテストに用いるモックオブジェクトにおいて、中身が空のフォルダもasFolder traitを指定するように修正。

## Side Effects

None

## QA Notes

None