### PR TITLE
[GRDM-43834] メタデータのスキーマ・補完の強化他

### DIFF
--- a/app/models/schema-block.ts
+++ b/app/models/schema-block.ts
@@ -17,6 +17,7 @@ export default class SchemaBlockModel extends OsfModel implements SchemaBlock {
     @attr('string') helpText?: string;
     @attr('string') exampleText?: string;
     @attr('boolean') required?: boolean;
+    @attr('string') requiredIf?: string;
     @attr('boolean') default?: boolean;
     @attr('number') index?: number;
     @attr('string') pattern?: string;

--- a/app/packages/registration-schema/get-schema-block-group.ts
+++ b/app/packages/registration-schema/get-schema-block-group.ts
@@ -53,13 +53,8 @@ export function getSchemaBlockGroups(blocks: SchemaBlock[] | undefined) {
             case 'e-rad-bunnya-input':
             case 'file-metadata-input':
             case 'date-input':
-            case 'file-capacity-input':
-            case 'file-creators-input':
-            case 'file-url-input':
-            case 'file-institution-ja-input':
-            case 'file-institution-en-input':
-            case 'file-institution-id-input':
-            case 'file-data-number-input':
+            case 'section-heading':
+            case 'subsection-heading':
 
                 assert('input block with no registrationResponseKey!', !isEmpty(block.registrationResponseKey));
                 assert('question with multiple input blocks!', !schemaBlockGroup.inputBlock);

--- a/app/packages/registration-schema/index.ts
+++ b/app/packages/registration-schema/index.ts
@@ -2,7 +2,7 @@ export { getPages } from './get-pages';
 export { getSchemaBlockGroups } from './get-schema-block-group';
 export { SchemaBlock, SchemaBlockType } from './schema-block';
 export { SchemaBlockGroup } from './schema-block-group';
-export { buildValidation, buildMetadataValidations } from './validations';
+export { buildValidation, buildMetadataValidations, setupEventForSyncValidation } from './validations';
 export {
     FileReference,
     RegistrationResponse,

--- a/app/packages/registration-schema/page-manager.ts
+++ b/app/packages/registration-schema/page-manager.ts
@@ -9,6 +9,7 @@ import {
     getSchemaBlockGroups,
     SchemaBlock,
     SchemaBlockGroup,
+    setupEventForSyncValidation,
 } from 'ember-osf-web/packages/registration-schema';
 import { RegistrationResponse } from 'ember-osf-web/packages/registration-schema/registration-response';
 
@@ -33,6 +34,7 @@ export class PageManager {
                 lookupValidator(validations),
                 validations,
             ) as ChangesetDef;
+            setupEventForSyncValidation(this.changeset, this.schemaBlockGroups);
 
             if (this.isVisited) {
                 this.changeset.validate();

--- a/app/packages/registration-schema/schema-block-group.ts
+++ b/app/packages/registration-schema/schema-block-group.ts
@@ -9,4 +9,5 @@ export interface SchemaBlockGroup {
     registrationResponseKey?: string | null;
     groupType?: string;
     blocks?: SchemaBlock[];
+    children?: SchemaBlockGroup[];
   }

--- a/app/packages/registration-schema/schema-block.ts
+++ b/app/packages/registration-schema/schema-block.ts
@@ -26,14 +26,7 @@ export type SchemaBlockType =
     'e-rad-researcher-name-en-input' |
     'e-rad-bunnya-input' |
     'file-metadata-input' |
-    'date-input' |
-    'file-capacity-input' |
-    'file-creators-input' |
-    'file-url-input' |
-    'file-institution-ja-input' |
-    'file-institution-en-input' |
-    'file-institution-id-input' |
-    'file-data-number-input';
+    'date-input';
 
 export interface SchemaBlock {
     id?: string;
@@ -44,6 +37,7 @@ export interface SchemaBlock {
     helpText?: string;
     exampleText?: string;
     required?: boolean;
+    requiredIf?: string;
     default?: boolean;
     index?: number;
     pattern?: string;

--- a/app/packages/registration-schema/schema-block.ts
+++ b/app/packages/registration-schema/schema-block.ts
@@ -26,7 +26,8 @@ export type SchemaBlockType =
     'e-rad-researcher-name-en-input' |
     'e-rad-bunnya-input' |
     'file-metadata-input' |
-    'date-input';
+    'date-input' |
+    'array-input';
 
 export interface SchemaBlock {
     id?: string;

--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -3,11 +3,13 @@ import { set } from '@ember/object';
 import { ValidationObject, ValidatorFunction } from 'ember-changeset-validations';
 import { validateFormat, validatePresence } from 'ember-changeset-validations/validators';
 
+import { ValidationResult } from 'ember-changeset-validations/utils/validation-errors';
+import { ChangesetDef } from 'ember-changeset/types';
 import DraftRegistration, { DraftMetadataProperties } from 'ember-osf-web/models/draft-registration';
 import NodeModel, { NodeLicense } from 'ember-osf-web/models/node';
 import { RegistrationResponse } from 'ember-osf-web/packages/registration-schema';
 import { SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema/schema-block-group';
-import { validateFileList } from 'ember-osf-web/validators/validate-response-format';
+import { validateFileList, validateRequiredIf } from 'ember-osf-web/validators/validate-response-format';
 
 export const NodeLicenseFields: Record<keyof NodeLicense, string> = {
     copyrightHolders: 'Copyright Holders',
@@ -55,6 +57,11 @@ export function buildValidation(groups: SchemaBlockGroup[], node?: NodeModel) {
                     validateFileList(responseKey as string, node),
                 );
             }
+            if (inputBlock.requiredIf) {
+                validationForResponse.push(
+                    validateRequiredIf(inputBlock.requiredIf, groups),
+                );
+            }
             if (inputBlock.pattern) {
                 const key = (group.registrationResponseKey || '').substr('__responseKey_'.length);
                 validationForResponse.push(
@@ -81,6 +88,47 @@ export function buildValidation(groups: SchemaBlockGroup[], node?: NodeModel) {
         }
     });
     return ret;
+}
+
+export function setupEventForSyncValidation(changeset: ChangesetDef, groups: SchemaBlockGroup[]) {
+    const requiredIfGroups = groups
+        // ignore GRDM file specific fields
+        .filter((group: SchemaBlockGroup) => !group.registrationResponseKey
+            || !group.registrationResponseKey.match(/^__responseKey_grdm-file:.+$/))
+        .filter((group: SchemaBlockGroup) => group.inputBlock && group.inputBlock.requiredIf);
+    changeset.on('afterValidation', (key: string) => {
+        requiredIfGroups
+            .forEach(group => {
+                if (`__responseKey_${group.inputBlock!.requiredIf}` !== key) {
+                    return;
+                }
+                const errors = changeset.get('errors');
+                const otherKey = group.registrationResponseKey as string;
+                const contextCurrentValue = changeset.get(key);
+                const validationErrors = errors
+                    .filter((error: any) => error.key === otherKey)
+                    .flatMap((error: any) => error.validation as Array<string | ValidationResult>)
+                    .filter(
+                        (result: string | ValidationResult): result is ValidationResult => typeof result === 'object',
+                    )
+                    .filter(
+                        (result: ValidationResult) => result.context.type === 'invalid_required_if',
+                    );
+                const validatedContextValues: Array<{[key: string]: any}> = validationErrors
+                    .filter((result: ValidationResult) => typeof result.value === 'object')
+                    .map((result: ValidationResult) => result.value as {[key: string]: any});
+                const existMismatchError = validatedContextValues.some(
+                    values => values[key] !== contextCurrentValue,
+                );
+                if (existMismatchError) {
+                    changeset.validate(otherKey);
+                    return;
+                }
+                if (!contextCurrentValue && !validatedContextValues.filter(values => !values[key]).length) {
+                    changeset.validate(otherKey);
+                }
+            });
+    });
 }
 
 export function validateNodeLicense() {

--- a/app/validators/validate-response-format.ts
+++ b/app/validators/validate-response-format.ts
@@ -1,8 +1,10 @@
+import { assert } from '@ember/debug';
 import { isEmpty } from '@ember/utils';
 import { ValidatorFunction } from 'ember-changeset-validations';
 import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 import File from 'ember-osf-web/models/file';
 import NodeModel from 'ember-osf-web/models/node';
+import { SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema';
 import { allSettled } from 'rsvp';
 
 export function validateFileList(responseKey: string, node?: NodeModel): ValidatorFunction {
@@ -37,6 +39,44 @@ export function validateFileList(responseKey: string, node?: NodeModel): Validat
                     },
                 });
             }
+        }
+        return true;
+    };
+}
+
+export function validateRequiredIf(
+    requiredIf: string, groups: SchemaBlockGroup[],
+): ValidatorFunction {
+    return async (
+        key: string,
+        newValue: string,
+        _: string,
+        changes: Record<string, unknown>,
+        content: Record<string, unknown>,
+    ) => {
+        const otherKey = `__responseKey_${requiredIf}`;
+        const otherGroup = groups.find(group => group.registrationResponseKey === otherKey);
+        assert(
+            `no response key with label for group ${requiredIf} by requiredIf`,
+            otherGroup != null && otherGroup.labelBlock != null && otherGroup.labelBlock.displayText != null,
+        );
+        const displayText: string = (otherGroup && otherGroup.labelBlock && otherGroup.labelBlock.displayText) || '';
+        const otherValues = { ...content, ...changes } as {[key: string]: string};
+        const otherValue = otherValues[otherKey];
+        if (!newValue && !otherValue) {
+            return buildMessage(key, {
+                type: 'presence',
+                context: {
+                    type: 'invalid_required_if',
+                    translationArgs: {
+                        otherLabel: displayText,
+                    },
+                },
+                value: {
+                    [key]: newValue,
+                    [otherKey]: otherValue,
+                },
+            });
         }
         return true;
     };

--- a/lib/osf-components/addon/components/registries/page-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/page-renderer/template.hbs
@@ -11,6 +11,7 @@
                 metadataNodeProject=this.draftManager.metadataNodeProject
                 onMetadataInput=@onMetadataInput
                 draftManager=this.draftManager
+                schemaBlockGroup=group
         }}
     />
 {{/each}}

--- a/lib/osf-components/addon/components/registries/review-form-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/review-form-renderer/template.hbs
@@ -11,6 +11,7 @@
                 node=@node
                 changeset=pageManager.changeset
                 draftManager=@draftManager
+                schemaBlockGroup=group
             }}
         />
     {{/each}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
@@ -164,4 +164,16 @@
         metadataNodeProject=@metadataNodeProject
         draftManager=@draftManager
     )
+    array-input=(
+        component
+        'registries/schema-block-renderer/editable/rdm/array-input'
+        changeset=@changeset
+        metadataChangeset=@metadataChangeset
+        onInput=@onInput
+        onMetadataInput=@onMetadataInput
+        node=@node
+        metadataNodeErad=@metadataNodeErad
+        draftManager=@draftManager
+        schemaBlockGroup=@schemaBlockGroup
+    )
 )}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/array-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/array-input/component.ts
@@ -1,0 +1,101 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import Changeset from 'ember-changeset';
+import lookupValidator from 'ember-changeset-validations';
+import { ChangesetDef } from 'ember-changeset/types';
+import { layout } from 'ember-osf-web/decorators/component';
+import NodeModel from 'ember-osf-web/models/node';
+import { buildValidation, SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema';
+import DraftRegistrationManager from 'registries/drafts/draft/draft-registration-manager';
+import styles from './styles';
+import template from './template';
+
+@layout(template, styles)
+@tagName('')
+export default class ArrayInput extends Component {
+    // Required param
+    changeset!: ChangesetDef;
+    metadataChangeset!: ChangesetDef;
+    draftManager!: DraftRegistrationManager;
+
+    @alias('schemaBlock.registrationResponseKey')
+    valuePath!: string;
+    onInput!: () => void;
+    onMetadataInput!: () => void;
+    schemaBlockGroup!: SchemaBlockGroup;
+    node!: NodeModel;
+
+    subChangesets: ChangesetDef[] = [];
+
+    didReceiveAttrs() {
+        const raw = this.changeset.get(this.valuePath);
+        if (raw) {
+            const prefix = `${this.valuePath}|`;
+            const values = JSON.parse(raw);
+            const subChangesets: ChangesetDef[] = values.map((row: Array<{key: string, value: any}>) => {
+                const subChangeset = this.createSubChangeset();
+                Object.entries(row).forEach(([k, v]) => {
+                    const key2 = `${prefix}${k}`;
+                    subChangeset.set(key2, v);
+                });
+                subChangeset.on('afterValidation', () => {
+                    this.save(this.get('subChangesets'));
+                });
+                return subChangeset;
+            });
+            this.set('subChangesets', subChangesets);
+        } else {
+            this.set('subChangesets', []);
+        }
+    }
+
+    save(subChangesets: ChangesetDef[]) {
+        const prefix = `${this.valuePath}|`;
+        const allChanges = subChangesets.map(changeset => {
+            const changes: Array<{key: string, value: any}> = changeset.changes as any;
+            const row: {[key: string]: any} = {};
+            changes.forEach(({ key, value }) => {
+                assert(
+                    `Sub changeset key ${key} requires starting with parent key ${prefix}`,
+                    key.startsWith(prefix),
+                );
+                const key2 = key.substr(prefix.length);
+                row[key2] = value;
+            });
+            return row;
+        }).filter(changes => Object.keys(changes).length);
+        // todo: exclude rows where all values are empty
+        this.changeset.set(this.valuePath, JSON.stringify(allChanges));
+    }
+
+    createSubChangeset() {
+        const validations = buildValidation(this.schemaBlockGroup.children!, this.node);
+        const subChangeset = new Changeset(
+            {},
+            lookupValidator(validations),
+            validations,
+        ) as ChangesetDef;
+        // todo: setupEventForSyncValidation
+        return subChangeset;
+    }
+
+    @action
+    onAdd() {
+        const subChangeset = this.createSubChangeset();
+        this.set('subChangesets', [...this.get('subChangesets'), subChangeset]);
+        subChangeset.on('afterValidation', () => {
+            this.save(this.get('subChangesets'));
+        });
+    }
+
+    @action
+    onRemove(subChangeset: ChangesetDef) {
+        const newSubChangesets = this.get('subChangesets').filter(c => c !== subChangeset);
+        this.set('subChangesets', newSubChangesets);
+        this.save(newSubChangesets);
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/array-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/array-input/styles.scss
@@ -1,0 +1,10 @@
+.array-input-item-container {
+    border: 4px solid #eee;
+    padding: 14px;
+    border-radius: 8px;
+    margin: 10px 0;
+}
+
+.array-input-remove-button {
+    margin-top: 20px;
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/array-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/array-input/template.hbs
@@ -1,0 +1,38 @@
+<Registries::SchemaBlockRenderer::Editable::Base @helpText={{this.schemaBlock.helpText}}>
+
+    {{#each this.subChangesets as |subChangeset|}}
+        <div local-class='array-input-item-container'>
+            {{#each @schemaBlockGroup.children as |group|}}
+                <Registries::SchemaBlockGroupRenderer
+                    @schemaBlockGroup={{group}}
+                    @renderStrategy={{
+                        component
+                        'registries/schema-block-renderer/editable/mapper'
+                        changeset=subChangeset
+                        node=@node
+                        onInput=@onInput
+                        metadataChangeset=this.draftManager.metadataChangeset
+                        metadataNodeErad=this.draftManager.metadataNodeErad
+                        metadataNodeProject=this.draftManager.metadataNodeProject
+                        onMetadataInput=@onMetadataInput
+                        draftManager=this.draftManager
+                        schemaBlockGroup=group
+                    }}
+                />
+            {{/each}}
+            <OsfButton local-class='array-input-remove-button'
+              @onClick={{action this.onRemove subChangeset}}
+            >
+                {{t 'metadata.array-input.remove-item'}}
+            </OsfButton>
+        </div>
+    {{/each}}
+
+    <OsfButton local-class='array-input-add-button'
+      @type='primary'
+      @onClick={{action this.onAdd}}
+    >
+        {{t 'metadata.array-input.add-item'}}
+    </OsfButton>
+
+</Registries::SchemaBlockRenderer::Editable::Base>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-title-en-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-title-en-input/template.hbs
@@ -11,6 +11,7 @@
             @uniqueID={{@uniqueID}}
             @valuePath={{@schemaBlock.registrationResponseKey}}
             @onChange={{action this.onInput2}}
+            @onKeyUp={{action this.onInput2}}
             @placeholder=' '
         />
     </FormControls>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-title-ja-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-title-ja-input/template.hbs
@@ -11,6 +11,7 @@
             @uniqueID={{@uniqueID}}
             @valuePath={{@schemaBlock.registrationResponseKey}}
             @onChange={{action this.onInput2}}
+            @onKeyUp={{action this.onInput2}}
             @placeholder=' '
         />
     </FormControls>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/component.ts
@@ -253,19 +253,24 @@ export default class FileMetadataInput extends Component {
         if (!managerJa && !managerEn) {
             return null;
         }
+        let value;
         if (managerJa && !managerEn) {
-            return `${managerJa.value}`;
+            value = managerJa.value;
+        } else if (!managerJa && managerEn) {
+            value = managerEn.value;
+        } else if (this.intl.locale.includes('ja')) {
+            value = managerJa.value;
+        } else {
+            value = managerEn.value;
         }
-        if (!managerJa && managerEn) {
-            return `${managerEn.value}`;
+        if (value && typeof value === 'object') {
+            return (
+                this.intl.locale.includes('ja')
+                    ? [value.last, value.middle, value.first]
+                    : [value.first, value.middle, value.last]
+            ).filter(v => v).join(' ');
         }
-        if (!managerJa.value && !managerEn.value) {
-            return null;
-        }
-        if (this.intl.locale.includes('ja')) {
-            return `${managerJa.value}`;
-        }
-        return `${managerEn.value}`;
+        return value;
     }
 
     extractUrlFromMetadata(metadata: FileMetadata): string | null {

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/text/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/text/styles.scss
@@ -1,7 +1,6 @@
 .schema-block-input {
     :global(input) {
         height: 40px;
-        background-color: $color-bg-gray-blue-light;
         color: $color-text-gray-blue;
         border-radius: 2px;
         box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/textarea/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/textarea/styles.scss
@@ -2,7 +2,6 @@
     :global(.form-control) {
         min-height: 100px;
         color: $color-text-gray-blue;
-        background-color: $color-bg-gray-blue-light;
         border: 1px solid $color-border-gray;
         border-radius: 2px;
         font-size: 14px;

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
@@ -117,4 +117,13 @@
         changeset=@changeset
         node=@node
     )
+    array-input=(
+        component
+        'registries/schema-block-renderer/read-only/rdm/array-input'
+        registrationResponses=@registrationResponses
+        changeset=@changeset
+        node=@node
+        draftManager=@draftManager
+        schemaBlockGroup=@schemaBlockGroup
+    )
 )}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/array-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/array-input/component.ts
@@ -1,0 +1,75 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+
+import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import Changeset from 'ember-changeset';
+import lookupValidator from 'ember-changeset-validations';
+import { ChangesetDef } from 'ember-changeset/types';
+import { layout } from 'ember-osf-web/decorators/component';
+import NodeModel from 'ember-osf-web/models/node';
+import {
+    buildValidation,
+    RegistrationResponse,
+    SchemaBlock,
+    SchemaBlockGroup,
+} from 'ember-osf-web/packages/registration-schema';
+import styles from './styles';
+import template from './template';
+
+@layout(template, styles)
+@tagName('')
+export default class ArrayInput extends Component {
+    // Required param
+    changeset!: ChangesetDef;
+    registrationResponses!: RegistrationResponse;
+    schemaBlock!: SchemaBlock;
+
+    @alias('schemaBlock.registrationResponseKey')
+    valuePath!: string;
+    schemaBlockGroup!: SchemaBlockGroup;
+    node!: NodeModel;
+
+    subChangesets: ChangesetDef[] = [];
+
+    didReceiveAttrs() {
+        const raw = this.registrationResponses[this.valuePath] as string;
+        if (raw) {
+            const prefix = `${this.valuePath}|`;
+            const values = JSON.parse(raw);
+            const subChangesets: ChangesetDef[] = values.map((row: Array<{key: string, value: any}>) => {
+                const subChangeset = this.createSubChangeset();
+                Object.entries(row).forEach(([k, v]) => {
+                    const key2 = `${prefix}${k}`;
+                    subChangeset.set(key2, v);
+                });
+                return subChangeset;
+            });
+            this.set('subChangesets', subChangesets);
+        } else {
+            this.set('subChangesets', []);
+        }
+    }
+
+    @computed('subChangesets')
+    get subs() {
+        return this.get('subChangesets').map(subChangeset => {
+            const changes: Array<{key: string, value: any}> = subChangeset.changes as any;
+            const subRegistrationResponse: {[key: string]: any} = {};
+            changes.forEach(({ key, value }) => {
+                subRegistrationResponse[key] = value;
+            });
+            return { subChangeset, subRegistrationResponse };
+        });
+    }
+
+    createSubChangeset() {
+        const validations = buildValidation(this.schemaBlockGroup.children!, this.node);
+        const subChangeset = new Changeset(
+            {},
+            lookupValidator(validations),
+            validations,
+        ) as ChangesetDef;
+        return subChangeset;
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/array-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/array-input/styles.scss
@@ -1,0 +1,6 @@
+.array-input-item-container {
+    border: 4px solid #eee;
+    padding: 14px;
+    border-radius: 8px;
+    margin: 10px 0;
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/array-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/array-input/template.hbs
@@ -1,0 +1,18 @@
+{{#each this.subs as |sub|}}
+    <div local-class='array-input-item-container'>
+        {{#each @schemaBlockGroup.children as |group|}}
+            <Registries::SchemaBlockGroupRenderer
+                @schemaBlockGroup={{group}}
+                @renderStrategy={{
+                    component
+                    'registries/schema-block-renderer/read-only/mapper'
+                    registrationResponses=sub.subRegistrationResponse
+                    changeset=sub.subChangeset
+                    node=@node
+                    draftManager=this.draftManager
+                    schemaBlockGroup=group
+                }}
+            />
+        {{/each}}
+    </div>
+{{/each}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/section-heading/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/section-heading/component.ts
@@ -1,11 +1,54 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Intl from 'ember-intl/services/intl';
 import { layout } from 'ember-osf-web/decorators/component';
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema';
 import styles from './styles';
 import template from './template';
 
 @layout(template, styles)
 @tagName('')
 export default class SectionHeading extends Component {
+    @service intl!: Intl;
+    // Required params
+    schemaBlock!: SchemaBlock;
+
+    @computed('schemaBlock')
+    get localizedDisplayText() {
+        const text = this.schemaBlock.displayText;
+        if (!text) {
+            return text;
+        }
+        if (!text.includes('|')) {
+            return text;
+        }
+        const texts = text.split('|');
+        if (this.intl.locale.includes('ja')) {
+            return texts[0];
+        }
+        return texts[1];
+    }
+
+    @computed('schemaBlock')
+    get localizedHelpText() {
+        const text = this.schemaBlock.helpText;
+        if (!text) {
+            return text;
+        }
+        return this.getLocalizedText(text);
+    }
+
+    getLocalizedText(text: string) {
+        if (!text.includes('|')) {
+            return text;
+        }
+        const texts = text.split('|');
+        if (this.intl.locale.includes('ja')) {
+            return texts[0];
+        }
+        return texts[1];
+    }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/section-heading/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/section-heading/template.hbs
@@ -3,10 +3,10 @@
     id={{@schemaBlock.elementId}}
     ...attributes
 >
-    {{@schemaBlock.displayText}}
+    {{this.localizedDisplayText}}
     <span>
         {{#if this.isEditableForm}}
-            <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{this.schemaBlock.helpText}} />
+            <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{this.localizedHelpText}} />
         {{/if}}
     </span>
 </h3>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/subsection-heading/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/subsection-heading/component.ts
@@ -1,11 +1,54 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Intl from 'ember-intl/services/intl';
 import { layout } from 'ember-osf-web/decorators/component';
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema';
 import styles from './styles';
 import template from './template';
 
 @layout(template, styles)
 @tagName('')
 export default class SubsectionHeading extends Component {
+    @service intl!: Intl;
+    // Required params
+    schemaBlock!: SchemaBlock;
+
+    @computed('schemaBlock')
+    get localizedDisplayText() {
+        const text = this.schemaBlock.displayText;
+        if (!text) {
+            return text;
+        }
+        if (!text.includes('|')) {
+            return text;
+        }
+        const texts = text.split('|');
+        if (this.intl.locale.includes('ja')) {
+            return texts[0];
+        }
+        return texts[1];
+    }
+
+    @computed('schemaBlock')
+    get localizedHelpText() {
+        const text = this.schemaBlock.helpText;
+        if (!text) {
+            return text;
+        }
+        return this.getLocalizedText(text);
+    }
+
+    getLocalizedText(text: string) {
+        if (!text.includes('|')) {
+            return text;
+        }
+        const texts = text.split('|');
+        if (this.intl.locale.includes('ja')) {
+            return texts[0];
+        }
+        return texts[1];
+    }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/subsection-heading/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/subsection-heading/template.hbs
@@ -4,10 +4,10 @@
     data-test-subsection-heading
     ...attributes
 >
-    {{@schemaBlock.displayText}}
+    {{this.localizedDisplayText}}
     <span>
         {{#if this.isEditableForm}}
-            <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{this.schemaBlock.helpText}} />
+            <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{this.localizedHelpText}} />
         {{/if}}
     </span>
 </h4>

--- a/lib/osf-components/addon/components/validation-errors/component.ts
+++ b/lib/osf-components/addon/components/validation-errors/component.ts
@@ -48,9 +48,14 @@ export default class ValidationErrors extends Component<Args> {
 
             if (Array.isArray(validatorErrors)) {
                 return validatorErrors.map(
-                    ({ context: { type, translationArgs } }) => this.intl.t(
-                        `validationErrors.${type}`, { ...translationArgs },
-                    ),
+                    ({ context: { type, translationArgs } }) => {
+                        const localizedArgs: Array<[string, (string | number)]> = Object.entries(translationArgs || {})
+                            .map(([k, v]) => [k, this.getLocalizedText(v)]);
+                        const localizedArgMap = localizedArgs.reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {});
+                        return this.intl.t(
+                            `validationErrors.${type}`, localizedArgMap,
+                        );
+                    },
                 );
             }
         }
@@ -60,5 +65,19 @@ export default class ValidationErrors extends Component<Args> {
     get validatorErrors() {
         const { errors, validatorResults } = this;
         return isEmpty(errors) ? validatorResults : errors;
+    }
+
+    getLocalizedText(text: string | number): string | number {
+        if (typeof text !== 'string') {
+            return text;
+        }
+        if (!text.includes('|')) {
+            return text;
+        }
+        const texts = text.split('|');
+        if (this.intl.locale.includes('ja')) {
+            return texts[0];
+        }
+        return texts[1];
     }
 }

--- a/lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/array-input/component.js
+++ b/lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/array-input/component.js
@@ -1,0 +1,2 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/editable/rdm/array-input/component';

--- a/lib/osf-components/app/components/registries/schema-block-renderer/read-only/rdm/array-input/component.js
+++ b/lib/osf-components/app/components/registries/schema-block-renderer/read-only/rdm/array-input/component.js
@@ -1,0 +1,2 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/read-only/rdm/array-input/component';

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1848,3 +1848,6 @@ metadata:
         export-dialog:
             title: 'Select a report format'
             description: 'Select the report format you want to output.'
+    array-input:
+        add-item: 'Add item'
+        remove-item: 'Remove item'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -538,6 +538,7 @@ validationErrors:
     year_format: 'Please specify a valid year.'
     invalid_format_funder: 'Please use single-byte alphanumeric characters.'
     invalid_format_funding-stream-code: 'Please enter up to 5 single-byte alphanumeric characters.'
+    invalid_required_if: 'One of this field or "{otherLabel}" field must be filled.'
 validated_input_form:
     discard_changes: 'Discard changes'
 node_navbar:

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -1848,3 +1848,6 @@ metadata:
         export-dialog:
             title: '報告書フォーマットの選択'
             description: '出力したい報告書のフォーマットを選択してください。'
+    array-input:
+        add-item: 'アイテム追加'
+        remove-item: 'アイテム削除'

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -538,6 +538,7 @@ validationErrors:
     year_format: 'Please specify a valid year.'
     invalid_format_funder: '半角英数字で入力してください。'
     invalid_format_funding-stream-code: '5文字以内の半角英数字で入力してください。'
+    invalid_required_if: 'このフィールドか「{otherLabel}」のいずれかを入力する必要があります。'
 validated_input_form:
     discard_changes: 変更を破棄
 node_navbar:


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: GRDM-43834 (代表チケット)
- Feature flag: n/a

osf.io側の実装は https://github.com/RCOSDP/RDM-osf.io/pull/524 です。同時にマージしてください。

## Purpose

メタデータスキーマの表現能力を向上するため、スキーマ定義の拡張を行います。

https://github.com/RCOSDP/RDM-ember-osf-web/pull/111 と https://github.com/RCOSDP/RDM-ember-osf-web/pull/112 をまとめて反映するものです。

## Summary of Changes

- GRDM-38885: 条件付きの必須プロパティ(required_if)を実装しました
- GRDM-39551, GRDM-39553: fileメタデータのtype: array, type: objectのヘッダーが表示されないよう修正しました
- type: array に対応したarray-inputブロックを実装しました。

## Side Effects

None

## QA Notes

None