### PR TITLE
ダッシュボード表示のユーザ体験向上施策

### DIFF
--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -88,7 +88,6 @@ export default class Dashboard extends Controller {
 
         const nodes: QueryHasManyResult<Node> = yield user.queryHasMany('sparseNodes', {
             embed: ['parent', 'root'],
-            // eslint-disable-next-line ember/no-global-jquery
             fields: {
                 users: 'full_name, given_name, middle_names, family_name',
                 'sparse-nodes': 'id,title, date_modified, bibliographic_contributors, parent, root, creator',

--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -87,7 +87,12 @@ export default class Dashboard extends Controller {
         const user: User = yield this.currentUser.user;
 
         const nodes: QueryHasManyResult<Node> = yield user.queryHasMany('sparseNodes', {
-            embed: ['bibliographic_contributors', 'parent', 'root'],
+            embed: ['parent', 'root'],
+            // eslint-disable-next-line ember/no-global-jquery
+            fields: {
+                users: 'full_name, given_name, middle_names, family_name',
+                'sparse-nodes': 'id,title, date_modified, bibliographic_contributors, parent, root, creator',
+            },
             // eslint-disable-next-line ember/no-global-jquery
             filter: this.filter ? { title: $('<div>').text(this.filter).html() } : undefined,
             page: more ? this.incrementProperty('page') : this.set('page', 1),

--- a/lib/osf-components/addon/components/contributor-list/component.ts
+++ b/lib/osf-components/addon/components/contributor-list/component.ts
@@ -60,7 +60,15 @@ export default class ContributorList extends Component {
             this.set('totalContributors', nextPage.meta.total);
         } else {
             this.set('page', 1);
-            const firstPage = yield this.node.bibliographicContributors;
+            const firstPage = yield this.node.queryHasMany(
+                'bibliographicContributors',
+                {
+                    fields: {
+                        users: 'full_name, given_name, family_name, id, links',
+                    },
+                    page: { size: 3 },
+                },
+            );
             this.setProperties({
                 displayedContributors: firstPage.toArray(),
                 totalContributors: firstPage.meta.total,

--- a/lib/osf-components/addon/components/contributor-list/component.ts
+++ b/lib/osf-components/addon/components/contributor-list/component.ts
@@ -66,7 +66,7 @@ export default class ContributorList extends Component {
                     fields: {
                         users: 'full_name, given_name, family_name, id, links',
                     },
-                    page: { size: 3 },
+                    page: { size: 10 },
                 },
             );
             this.setProperties({


### PR DESCRIPTION
## Purpose

nodesを取得する箇所でAPIからの応答に時間がかかっており、ユーザ体験に影響を与えている

## Changes

- クエリセットの改良: bibliographicContributorsの取得において、queryHasManyを使用し、ページングと必要なフィールドの指定を行い、効率的にデータを取得する

- ContributorList コンポーネントの改良:コントリビュータのリストを取得時に、ページサイズを指定
   これにより、最初の3人のコントリビュータが表示される

## QA Notes

同時にリリースする必要があるプルリクエスト
https://github.com/RCOSDP/RDM-osf.io/pull/526

## Documentation



## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://redmine.devops.rcos.nii.ac.jp/issues/44236
