### PR TITLE
プロジェクトでファイルメタデータをチェックして消した後に未入力扱いにならない不具合の修正

### DIFF
--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/file-metadata-input/component.ts
@@ -192,7 +192,10 @@ export default class FileMetadataInput extends Component {
 
     saveFileMetadatas(metadatas: FileMetadata[]) {
         metadatas.sort((a, b) => a.path.localeCompare(b.path));
-        this.changeset.set(this.valuePath, JSON.stringify(metadatas));
+        this.changeset.set(
+            this.valuePath,
+            metadatas.length ? JSON.stringify(metadatas) : null,
+        );
         this.onInput();
         this.notifyPropertyChange('fileMetadatas');
     }


### PR DESCRIPTION

- Ticket: []
- Feature flag: n/a

## Purpose

プロジェクトでファイルメタデータをチェックして消した後に未入力扱いにならない不具合を修正しました。

## Summary of Changes

* ファイルメタデータが空のとき値を null にするよう修正

## Side Effects

None

## QA Notes

None
