### PR TITLE
[GRDM-44130, 44129, 47160] BinderHubアドオンのUIの改良 (RCOS環境)

### DIFF
--- a/app/adapters/custom-base-image.ts
+++ b/app/adapters/custom-base-image.ts
@@ -1,0 +1,54 @@
+import EmberError from '@ember/error';
+import DS from 'ember-data';
+
+import config from 'ember-get-config';
+
+import OsfAdapter from './osf-adapter';
+
+const {
+    OSF: {
+        url: host,
+        webApiNamespace: namespace,
+    },
+} = config;
+
+export default class CustomBaseImageAdapter extends OsfAdapter {
+    host = host.replace(/\/+$/, '');
+    namespace = namespace;
+    buildURL(
+        _: string | undefined,
+        id: string | null,
+        snapshot: DS.Snapshot | null,
+        requestType: string,
+        query?: { 'guid': string },
+    ): string {
+        const nodeUrl = super.buildURL('node', null, snapshot, requestType, query);
+        const url = nodeUrl.replace(/\/nodes\/$/, '/project/');
+        if (typeof query === 'undefined') {
+            if (snapshot === null) {
+                throw new EmberError(
+                    'Malformed arguments. `snapshot` is null and `query` is undefined.',
+                );
+            }
+            if (typeof snapshot.adapterOptions === 'undefined') {
+                throw new EmberError(
+                    'Illegal method call. `snapshot.argumentOptions` and `query` are undefined.',
+                );
+            }
+            if ('guid' in snapshot.adapterOptions) {
+                const adapterOpts = snapshot.adapterOptions as {guid: string};
+                return `${url}${adapterOpts.guid}/binderhub/custom_base_image${id ? `/${id}` : ''}`;
+            }
+            throw new EmberError(
+                'Illegal method call. `{adapterOptions: {guid: (guid value)}}` must be specified.',
+            );
+        }
+        return `${url}${query.guid}/binderhub/custom_base_image${id ? `/${id}` : ''}`;
+    }
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        'custom-base-image': CustomBaseImageAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/adapters/matlab-product-name-list.ts
+++ b/app/adapters/matlab-product-name-list.ts
@@ -1,0 +1,64 @@
+import EmberError from '@ember/error';
+import DS from 'ember-data';
+
+import config from 'ember-get-config';
+
+import OsfAdapter from './osf-adapter';
+
+const {
+    OSF: {
+        url: host,
+        webApiNamespace: namespace,
+    },
+} = config;
+
+export default class MatlabProductNameListAdapter extends OsfAdapter {
+    host = host.replace(/\/+$/, '');
+    namespace = namespace;
+
+    buildURL(
+        _: string | undefined,
+        id: string | null,
+        snapshot: DS.Snapshot | null,
+        requestType: string,
+        query?: {},
+    ): string {
+        const nodeUrl = super.buildURL('node', null, snapshot, requestType, query);
+        const url = nodeUrl.replace(/\/nodes\/$/, '/project/');
+        // See app/adapters/server-annotations.ts for detailed
+        // explanation.
+        if (requestType !== 'findRecord') {
+            throw new EmberError(
+                'Request type other than `findRecord` is not yet implemented for MatlabProductNameList.',
+            );
+        }
+        if (id === null) {
+            throw new EmberError(
+                'Illegal method call. Argument `id` is null.',
+            );
+        }
+        if (snapshot === null) {
+            throw new EmberError(
+                'Malformed arguments. `snapshot` is `null`.',
+            );
+        }
+        if (typeof snapshot.adapterOptions === 'undefined') {
+            throw new EmberError(
+                'Illegal method call. `snapshot.argumentOptions` is undefined.',
+            );
+        }
+        if ('guid' in snapshot.adapterOptions) {
+            const adapterOpts = snapshot.adapterOptions as {guid: string};
+            return `${url}${adapterOpts.guid}/binderhub/matlab/product_name_list/${id}`;
+        }
+        throw new EmberError(
+            'Illegal method call. `{adapterOptions: {guid: (guid value)}}` must be specified.',
+        );
+    }
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        'matlab-product-name-list': MatlabProductNameListAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/guid-node/binderhub/-components/build-console/component.ts
+++ b/app/guid-node/binderhub/-components/build-console/component.ts
@@ -132,8 +132,6 @@ export default class BuildConsole extends Component {
             binderhubUrl.toString(),
             path,
             (result: BuildMessage) => {
-                // TODO: is this callback called repeatedly until the
-                // `result.phase` get `'ready'`? It's worth to know.
                 if (result.phase !== 'ready') {
                     return;
                 }

--- a/app/guid-node/binderhub/-components/host-selector/template.hbs
+++ b/app/guid-node/binderhub/-components/host-selector/template.hbs
@@ -8,7 +8,7 @@
             {{@selectedHost.name}}
         </strong>
         <OsfButton data-test-open-host-selector-dialogue
-          @type='link' {{on 'click' (fn this.updateOpenBit true)}}>
+          @type='link' onClick={{fn this.updateOpenBit true}}>
             {{t 'binderhub.host_info.change_host'}}
         </OsfButton>
     </div>
@@ -34,7 +34,7 @@
                                 <label data-test-host-selection-option>
                                     <input type='radio' name='host' value={{item.url}}
                                         checked={{eq @selectedHost.url.href item.url.href}}
-                                        {{on 'click' (fn this.pick item.url.href)}}
+                                        onClick={{fn this.pick item.url.href}}
                                     >
                                     {{item.name}}
                                 </label>
@@ -50,12 +50,12 @@
     </div>
     <modal.footer>
         <BsButton data-test-host-selector-dialogue-cancel
-            {{on 'click' (fn this.updateOpenBit false)}}
+            onClick={{fn this.updateOpenBit false}}
         >
             {{t 'general.cancel'}}
         </BsButton>
         <BsButton data-test-host-selector-dialogue-ok
-            {{on 'click' this.applyPicked}}
+            onClick={{this.applyPicked}}
             @type='success'
         >
             {{t 'general.ok'}}

--- a/app/guid-node/binderhub/-components/jupyter-servers-list/template.hbs
+++ b/app/guid-node/binderhub/-components/jupyter-servers-list/template.hbs
@@ -109,7 +109,7 @@
                                 </td>
                                 <td>
                                     <div data-test-delete-icon>
-                                        {{fa-icon 'fa-trash' size=2
+                                        {{fa-icon 'trash' size=2
                                         local-class='delete_icon'
                                         click=(action (mut this.showDeleteConfirmDialogTarget) server)}}
                                     </div>

--- a/app/guid-node/binderhub/-components/mpm-package-editor/component.ts
+++ b/app/guid-node/binderhub/-components/mpm-package-editor/component.ts
@@ -1,14 +1,56 @@
 import Component from '@ember/component';
+import EmberError from '@ember/error';
 import { action, computed } from '@ember/object';
+import { later } from '@ember/runloop';
+import { inject as service } from '@ember/service';
+import DS from 'ember-data';
 import { requiredAction } from 'ember-osf-web/decorators/component';
-import $ from 'jquery';
 
-export interface MpmConfig {
+import { MpmPackageEditorError } from 'ember-osf-web/guid-node/binderhub/errors';
+import Node from 'ember-osf-web/models/node';
+
+function productNameCategory(name: string): string {
+    const initial = name.charAt(0);
+    if (initial.charCodeAt(0) >= 65 && initial.charCodeAt(0) <= 90) {
+        return initial;
+    }
+    return '_';
+}
+
+function generateSegmentHighlightMap(text: string, highlightSequence: string[]) {
+    const loweredText = text.toLowerCase();
+    let start = 0;
+    const segmentHlMap = [];
+    for (const hl of highlightSequence) {
+        const pos = loweredText.indexOf(hl, start);
+        if (pos < 0) {
+            return [];
+        }
+        segmentHlMap.push(
+            { segment: text.substring(start, pos), highlight: false },
+            { segment: text.substring(pos, pos + hl.length), highlight: true },
+        );
+        start = pos + hl.length;
+    }
+    segmentHlMap.push({ segment: text.substring(start), highlight: false });
+    return segmentHlMap;
+}
+
+interface MpmConfig {
     release: string | null;
     products: string[] | null;
 }
 
+enum ManualAddState {
+    NONE = 'NONE',
+    SUCCESSED = 'SUCCESSED',
+    CONFLICT = 'CONFLICT',
+    INVALID = 'INVALID',
+}
+
 export default class MpmPackageEditor extends Component {
+    @service store!: DS.Store;
+
     node?: Node | null = null;
 
     label: string = this.label;
@@ -17,19 +59,23 @@ export default class MpmPackageEditor extends Component {
 
     config: MpmConfig | null = this.config;
 
-    editing: string = '';
+    availableReleases: string[] = [];
 
-    editingIndex: number = -1;
+    productNames: string[] = [];
 
-    editingName: string = '';
+    productNamesFindingBit: boolean = false;
 
-    releaseEditing: boolean = false;
+    productPicking: boolean = false;
+
+    filterQuery: string = '';
 
     @requiredAction onUpdate!: (config: MpmConfig) => void;
 
-    @requiredAction onEditingStart!: () => void;
+    manualProductName: string = '';
 
-    @requiredAction onEditingEnd!: () => void;
+    latestManualProductName: string = '';
+
+    manualAddState: ManualAddState = ManualAddState.NONE;
 
     @computed('config')
     get release() {
@@ -48,122 +94,169 @@ export default class MpmPackageEditor extends Component {
     }
 
     @action
-    addProduct(this: MpmPackageEditor) {
-        this.set('editingIndex', -1);
-        this.set('editingName', '');
-        if (!this.onEditingStart) {
-            return;
-        }
-        this.onEditingStart();
+    startProductPicking() {
+        this.set('productPicking', true);
+        this.set('filterQuery', '');
     }
 
     @action
-    confirmAdd(this: MpmPackageEditor, name: string) {
-        this.set('editingIndex', -1);
-        if (this.onEditingEnd) {
-            this.onEditingEnd();
+    initProductNames() {
+        if (this.get('release')) {
+            this.updateProductNames(this.get('release'));
+        }
+    }
+
+    @action
+    closeProductsAddDialogue() {
+        this.set('productPicking', false);
+        this.set('filterQuery', '');
+        this.set('manualProductName', '');
+        this.set('latestManualProductName', '');
+        this.set('manualAddState', ManualAddState.NONE);
+    }
+
+    @computed('release', 'productNames')
+    get productNamesCategorizedHash() {
+        const release = this.get('release') as string;
+        if (!release) {
+            return {};
+        }
+
+        return this.get('productNames').reduce(
+            (acc: {[key: string]: string[]}, name: string) => {
+                const category = productNameCategory(name);
+                const ar = acc[category] || [];
+                acc[category] = [...ar, name].sort();
+                return acc;
+            }, {},
+        );
+    }
+
+    @computed('release', 'filterQuery', 'productNames')
+    get annotatedProductNameArray() {
+        const release = this.get('release') as string;
+        if (!release) {
+            return [];
+        }
+        const highlightSequence = this.get('filterQuery').toLowerCase().split(' ');
+        const result = [];
+        for (const name of this.get('productNames')) {
+            const segmentHlMap = generateSegmentHighlightMap(name, highlightSequence);
+            if (segmentHlMap.length > 0) {
+                result.push({ name, segmentHlMap });
+            }
+        }
+        return result;
+    }
+
+    @computed('filterQuery')
+    get isFiltering() {
+        return this.get('filterQuery').length > 0;
+    }
+
+    @computed('productNamesCategorizedHash')
+    get productNameCategories() {
+        return Object.keys(this.get('productNamesCategorizedHash')).sort();
+    }
+
+    @computed('products')
+    get pickedProductsHash() {
+        return (this.products || []).reduce((acc, name) => {
+            acc[name] = true;
+            return acc;
+        }, {} as {[key: string]: boolean});
+    }
+
+    @action
+    addProduct(name: string) {
+        if (!this.release) {
+            throw new EmberError('Invalid State. An MPM release must be selected beforehand.');
         }
         if (!this.onUpdate) {
             return;
         }
-        const newProducts = (this.products || []).map(elem => elem);
-        newProducts.push(name);
+        if (name.length === 0) {
+            throw new MpmPackageEditorError('Invalid Operation. Product name must not be zero-length.');
+        }
+        if ((this.products || []).includes(name)) {
+            throw new MpmPackageEditorError(`Malformed Operation. Product ${name} is already picked.`);
+        }
         this.onUpdate({
             release: this.release,
-            products: newProducts,
+            products: [name, ...(this.products || [])].sort(),
         });
     }
 
     @action
-    cancelAdd(this: MpmPackageEditor) {
-        this.set('editingIndex', -1);
-        if (!this.onEditingEnd) {
-            return;
-        }
-        this.onEditingEnd();
-    }
-
-    @action
-    removeProduct(this: MpmPackageEditor, index: number) {
+    removeProduct(name: string) {
         if (!this.onUpdate) {
             return;
         }
-        const newProducts = (this.products || []).map(elem => elem);
-        newProducts.splice(index, 1);
         this.onUpdate({
             release: this.release,
-            products: newProducts,
+            products: (this.products || []).map(x => x).filter(picked => picked !== name),
         });
     }
 
     @action
-    editProduct(this: MpmPackageEditor, index: number) {
-        this.set('editingIndex', index);
-        const allProducts = this.get('products') || [];
-        const editingProduct = allProducts[index];
-        this.set('editingName', editingProduct);
-        if (!this.onEditingStart) {
-            return;
-        }
-        this.onEditingStart();
-    }
-
-    @action
-    confirmEdit(this: MpmPackageEditor, name: string) {
-        const index = this.get('editingIndex');
-        this.set('editingIndex', -1);
-        if (this.onEditingEnd) {
-            this.onEditingEnd();
-        }
-        if (!this.onUpdate) {
-            return;
-        }
-        const newProducts = (this.products || []).map(elem => elem);
-        newProducts.splice(index, 1, name);
-        this.onUpdate({
-            release: this.release,
-            products: newProducts,
-        });
-    }
-
-    @action
-    cancelEdit(this: MpmPackageEditor) {
-        this.set('editingIndex', -1);
-        if (!this.onEditingEnd) {
-            return;
-        }
-        this.onEditingEnd();
-    }
-
-    @action
-    confirmReleaseEdit(this: MpmPackageEditor) {
-        const value = $('.input-release-name').val();
-        this.set('releaseEditing', false);
+    pickRelease(release: string | null) {
         const { config } = this;
-        if (!this.onUpdate) {
+        if (!this.onUpdate || (config !== null && config.release === release)) {
             return;
         }
-        this.onUpdate({
-            release: value ? value.toString() : null,
-            products: config ? config.products : null,
-        });
+        this.updateProductNames(release);
+        this.onUpdate({ release, products: null });
+    }
+
+    updateProductNames(release: string | null) {
+        const { node } = this;
+        if (!node) {
+            throw new EmberError('Illegal state. The node object is not set.');
+        }
+        this.set('productNamesFindingBit', true);
+        later(async () => {
+            if (release !== null) {
+                const productNameList = await this.store.findRecord(
+                    'matlab-product-name-list',
+                    release,
+                    { adapterOptions: { guid: node.id } },
+                );
+                this.set('productNames', productNameList.names);
+            }
+            this.set('productNamesFindingBit', false);
+        }, 0);
     }
 
     @action
-    releaseKeyDown(this: MpmPackageEditor, event: KeyboardEvent) {
-        const { key } = event;
-        if (key !== 'Enter') {
-            return;
+    updateFilter(event: { target: HTMLInputElement }) {
+        this.set('filterQuery', event.target.value);
+    }
+
+    @action
+    onProductNameChanged(event: { target: HTMLInputElement }) {
+        this.set('manualProductName', event.target.value);
+        this.set('manualAddState', ManualAddState.NONE);
+    }
+
+    @action
+    addManualProductName(name: string) {
+        try {
+            const actualName = name.trim();
+            if (actualName === '' || actualName.match(/\s/)) {
+                this.set('manualAddState', ManualAddState.INVALID);
+                return;
+            }
+            this.addProduct(actualName);
+            this.set('manualProductName', '');
+            this.set('latestManualProductName', name);
+            this.set('manualAddState', ManualAddState.SUCCESSED);
+        } catch (e) {
+            if (e instanceof MpmPackageEditorError) {
+                this.set('latestManualProductName', name);
+                this.set('manualAddState', ManualAddState.CONFLICT);
+            } else {
+                throw e;
+            }
         }
-        const input = event.target as HTMLInputElement;
-        this.set('releaseEditing', false);
-        const { config } = this;
-        if (!this.onUpdate) {
-            return;
-        }
-        this.onUpdate({
-            release: input.value,
-            products: config ? config.products : null,
-        });
     }
 }

--- a/app/guid-node/binderhub/-components/mpm-package-editor/styles.scss
+++ b/app/guid-node/binderhub/-components/mpm-package-editor/styles.scss
@@ -3,17 +3,8 @@
     flex-wrap: nowrap;
 }
 
-.products_group {
-    display: flex;
-    flex-wrap: nowrap;
-}
-
-.release_label {
-    margin: auto 1em auto 0;
-}
-
-.products_label {
-    margin: auto 1em;
+.release_selector_button {
+    border-radius: 5px;
 }
 
 .package_editor {
@@ -31,51 +22,107 @@
     color: #000;
 }
 
-.package_item {
-    margin: auto 1em auto 0;
+.product_item {
+    margin: 0.5em 1em auto 0;
     border-radius: 0.85em;
     border: 1px solid #ccc;
     padding: 0 1em;
     background: #f8f8f8;
 }
 
-.package_item button {
+.product_item button {
     border: 0;
     background: transparent;
     padding: 0;
 }
 
-.package_add {
-    margin: auto;
+.product_add {
+    margin: auto 1em;
 }
 
-.package_add button {
+.product_add button {
     border-radius: 0.85em;
     font-size: 0.9em;
     padding: 2px 1em;
 }
 
-.products_list {
+.picked_products_list {
     display: flex;
+    flex-wrap: wrap;
 }
 
-.edit_release_name {
-    color: #000;
+.release_list {
+    background-color: #f8f8f8;
+    border-radius: 2px;
+    height: 200px;
+    overflow-y: scroll;
+
+    & > li > button {
+        color: #000;
+        width: 100%;
+        text-align: justify;
+    }
+
+    & > li > button:hover {
+        color: #fff;
+        background-color: #1e90ff;
+    }
 }
 
-.package_item_confirm {
-    border-style: none;
-    background: none;
-    color: #28a745;
+.products_filter_textarea {
+    resize: none;
 }
 
-.package_item_cancel {
-    border-style: none;
-    background: none;
-    color: #888;
+// A workaround to avoid a malformed behaviour of tab line.
+/* stylelint-disable-next-line selector-max-compound-selectors */
+.products_tabs > ul > li > a:hover {
+    border: 1px solid rgba(0, 0, 0, 0);
 }
 
-.package_help {
-    border-style: none;
-    background: none;
+.products_list_pane {
+    padding: 4px 10px;
+    max-height: 60vh;
+    overflow-y: scroll;
+}
+
+.products_list_entry_label {
+    white-space: nowrap;
+    width: 100%;
+
+    &:hover {
+        color: #fff;
+        background-color: #1e90ff;
+    }
+}
+
+.manual_product_name_area {
+    display: flex;
+    padding: 1em;
+}
+
+.manual_product_name_editor {
+    resize: none;
+}
+
+.manual_product_name_add_button {
+    margin: 0 1em;
+    width: max-content;
+}
+
+.inform_manual_add {
+    margin: 1em;
+    border-radius: 5px;
+    padding: 0.5em;
+
+    &.successed {
+        background-color: #98fb98;
+    }
+
+    &.failed {
+        background-color: #ff8484;
+    }
+}
+
+.inform_manual_add_msg {
+    margin: 0.5em;
 }

--- a/app/guid-node/binderhub/-components/mpm-package-editor/template.hbs
+++ b/app/guid-node/binderhub/-components/mpm-package-editor/template.hbs
@@ -8,104 +8,186 @@
         {{/if}}
     </div>
     <div local-class='release_group'>
-        <div local-class='release_label'>
-            {{t 'binderhub.deployment.release'}}
-        </div>
-        <div local-class='release'>
-            {{#if (and this.releaseEditing this.node.userHasWritePermission)}}
-                <input
-                    name='release_name'
-                    class='input-release-name'
-                    placeholder={{t 'binderhub.deployment.placeholders.release'}}
-                    value={{this.release}}
-                    onkeyup={{action this.releaseKeyDown target=this}}
-                    type='text'
-                >
-                <button
-                    data-test-named-item-confirm
-                    type='button'
-                    class='btn btn-default'
-                    local-class='package_item_confirm'
-                    {{action this.confirmReleaseEdit target=this}}
-                >
-                    <i class='fa fa-check' />
-                </button>
-                <button
-                    data-test-named-item-cancel
-                    type='button'
-                    class='btn btn-default'
-                    local-class='package_item_cancel'
-                    {{action (mut this.releaseEditing) false}}
-                >
-                    <i class='fa fa-times' />
-                </button>
-            {{else if this.node.userHasWritePermission}}
-                {{this.release}}
-                <button
-                    data-test-mpm-release-edit
-                    class='btn btn-link'
-                    local-class='edit_release_name'
-                    {{action (mut this.releaseEditing) true}}
-                >
-                    <i class='fa fa-edit'></i>
-                </button>
+        {{#if this.node.userHasWritePermission}}
+            <BsDropdown {{did-insert this.initProductNames}} as |dd|>
+                <dd.button data-test-current-release
+                    local-class='release_selector_button'>
+                    {{or this.release (t 'binderhub.deployment.release')}}
+                    <span class='caret'></span>
+                </dd.button>
+                <dd.menu local-class='release_list' as |menu|>
+                    {{#each this.availableReleases as |release|}}
+                        <menu.item>
+                            <OsfButton data-test-pick-release={{release}}
+                                onClick={{action this.pickRelease release}}>
+                                {{#if (eq release this.release)}}
+                                    {{#fa-stack as |s|}}
+                                        {{s.stack-1x 'fw'}}
+                                        {{s.stack-1x 'check'}}
+                                    {{/fa-stack}}
+                                {{else}}
+                                    {{#fa-stack as |s|}}
+                                        {{s.stack-1x 'fw'}}
+                                    {{/fa-stack}}
+                                {{/if}}
+                                <span>{{release}}</span>
+                            </OsfButton>
+                        </menu.item>
+                    {{/each}}
+                    <menu.item>
+                        <OsfButton data-test-clear-release
+                            onClick={{action this.pickRelease null}}>
+                            {{#fa-stack as |s|}}
+                                {{s.stack-1x 'fw'}}
+                            {{/fa-stack}}
+                            <span>{{t 'binderhub.deployment.clear_release'}}</span>
+                        </OsfButton>
+                    </menu.item>
+                </dd.menu>
+            </BsDropdown>
+            {{#if this.release}}
+                <div local-class='product_add'>
+                    <button
+                        data-test-mpm-product-add
+                        type='button'
+                        class='btn btn-default'
+                        disabled={{this.transitioningBit}}
+                        onClick={{this.startProductPicking}}
+                    >
+                        <i class='fa fa-edit' />
+                        {{t 'binderhub.deployment.edit_product_button_label'}}
+                    </button>
+                </div>
             {{/if}}
-        </div>
+        {{/if}}
     </div>
-    <div local-class='products_group'>
-        <div local-class='products_label'>
-            {{t 'binderhub.deployment.products'}}
-        </div>
-        <div local-class='products_list'>
-            {{#each this.products as |pkg index|}}
-                {{#if (and (eq this.editing 'editing') (eq index this.editingIndex))}}
-                    <GuidNode::Binderhub::-Components::NamedItemEditor
-                        @name={{this.editingName}}
-                        @onConfirm={{action this.confirmEdit}}
-                        @onCancel={{action this.cancelEdit}}
-                    />
-                {{else}}
-                    <div local-class='package_item'>
-                        {{#if this.node.userHasWritePermission}}
-                            <button
-                                data-test-mpm-product-edit-item={{index}}
-                                {{action this.editProduct index target=this}}
-                            >
-                                {{pkg}}
-                            </button>
-                            <button
-                                data-test-mpm-product-delete-item={{index}}
-                                {{action this.removeProduct index target=this}}
-                            >
-                                <i class='fa fa-times' />
-                            </button>
-                        {{else}}
-                            {{pkg}}
-                        {{/if}}
-                    </div>
-                {{/if}}
-            {{/each}}
-            {{#if (and (eq this.editing 'editing') (eq this.editingIndex -1))}}
-                <GuidNode::Binderhub::-Components::NamedItemEditor
-                    @name={{this.editingName}}
-                    @onConfirm={{action this.confirmAdd}}
-                    @onCancel={{action this.cancelAdd}}
-                />
-            {{else}}
-                {{#if (and this.node.userHasWritePermission (not (eq this.editing 'editing')))}}
-                    <div local-class='package_add'>
-                        <button
-                            data-test-mpm-product-add
-                            type='button'
-                            class='btn btn-default'
-                            {{action this.addProduct target=this}}
-                        >
-                            <i class='fa fa-plus' />
-                            {{t 'binderhub.deployment.add_package'}}
+    <div>
+        <div local-class='picked_products_list'>
+            {{#each this.products as |name index|}}
+                <div local-class='product_item'>
+                    {{#if this.node.userHasWritePermission}}
+                        <button data-test-mpm-product-edit-item={{index}}>
+                            {{name}}
                         </button>
-                    </div>
-                {{/if}}
-            {{/if}}
+                        <button
+                            data-test-mpm-product-delete-item={{index}}
+                            onClick={{fn this.removeProduct name}}
+                        >
+                            <i class='fa fa-times'/>
+                        </button>
+                    {{else}}
+                        {{name}}
+                    {{/if}}
+                </div>
+            {{/each}}
         </div>
     </div>
 </div>
+
+<BsModal data-test-matlab-product-editor
+    @open={{this.productPicking}} @onHide={{this.closeProductsAddDialogue}} as |modal|>
+    <modal.header>
+        <h4>{{t 'binderhub.deployment.edit_product_dialogue.title'}}</h4>
+        <textarea
+            class='form-control'
+            local-class='products_filter_textarea'
+            placeholder={{t 'binderhub.deployment.edit_product_dialogue.search_placeholder'}}
+            rows='1'
+            value={{this.filterQuery}}
+            onKeyUp={{this.updateFilter}}
+            />
+    </modal.header>
+    {{#if this.isFiltering}}
+        <div local-class='products_list_pane'>
+            {{#each this.annotatedProductNameArray as |info|}}
+                {{#let (get this.pickedProductsHash info.name) as |picked|}}
+                    <div>
+                        <label local-class='products_list_entry_label'>
+                            <input type='checkbox'
+                                name='productname'
+                                value={{info.name}}
+                                checked={{picked}}
+                                onClick={{fn (if picked this.removeProduct this.addProduct) info.name}}
+                            >
+                            <GuidNode::Binderhub::-Components::TextSegmentHighlight
+                                @segmentHighlightMap={{info.segmentHlMap}}
+                                />
+                        </label>
+                    </div>
+                {{/let}}
+            {{/each}}
+        </div>
+    {{else}}
+        <BsTab local-class='products_tabs' as |tab|>
+            {{#each this.productNameCategories as |cat|}}
+                <tab.pane local-class='products_list_pane' @title={{cat}}>
+                    {{#each (get this.productNamesCategorizedHash cat) as |name|}}
+                        {{#let (get this.pickedProductsHash name) as |picked|}}
+                            <div>
+                                <label local-class='products_list_entry_label'>
+                                    <input type='checkbox'
+                                        name='productname'
+                                        value={{name}}
+                                        checked={{picked}}
+                                        onClick={{fn (if picked this.removeProduct this.addProduct) name}}
+                                    >
+                                    {{name}}
+                                </label>
+                            </div>
+                        {{/let}}
+                    {{/each}}
+                </tab.pane>
+            {{/each}}
+            {{#if (not this.productNamesFindingBit)}}
+                <tab.pane
+                    local-class='products_list_pane'
+                    @title={{t 'binderhub.deployment.edit_product_dialogue.manual_edit.tab_title'}}
+                    >
+                    <div local-class='manual_product_name_area'>
+                        <textarea
+                            local-class='manual_product_name_editor'
+                            class='form-control'
+                            rows='1'
+                            value={{this.manualProductName}}
+                            onKeyUp={{this.onProductNameChanged}}
+                            />
+                        <button
+                            local-class='manual_product_name_add_button'
+                            type='button'
+                            class='btn btn-default'
+                            disabled={{not (get this.manualProductName 'length')}}
+                            onClick={{fn this.addManualProductName this.manualProductName}}
+                        >
+                            {{t 'binderhub.deployment.edit_product_dialogue.manual_edit.add_button'}}
+                        </button>
+                    </div>
+                    {{#if (eq this.manualAddState 'SUCCESSED')}}
+                        <div local-class='inform_manual_add successed'>
+                            <span local-class='inform_manual_add_msg'>
+                                {{t
+                                    'binderhub.deployment.edit_product_dialogue.manual_edit.message_on_add'
+                                    product_name=this.latestManualProductName
+                                }}
+                            </span>
+                        </div>
+                    {{else if (eq this.manualAddState 'CONFLICT')}}
+                        <div local-class='inform_manual_add failed'>
+                            <span local-class='inform_manual_add_msg'>
+                                {{t
+                                    'binderhub.deployment.edit_product_dialogue.manual_edit.message_on_conflict'
+                                    product_name=this.latestManualProductName
+                                }}
+                            </span>
+                        </div>
+                    {{else if (eq this.manualAddState 'INVALID')}}
+                        <div local-class='inform_manual_add failed'>
+                            <span local-class='inform_manual_add_msg'>
+                                {{t 'binderhub.deployment.edit_product_dialogue.manual_edit.message_on_invalid'}}
+                            </span>
+                        </div>
+                    {{/if}}
+                </tab.pane>
+            {{/if}}
+        </BsTab>
+    {{/if}}
+</BsModal>

--- a/app/guid-node/binderhub/-components/project-editor/base-image-entry/component.ts
+++ b/app/guid-node/binderhub/-components/project-editor/base-image-entry/component.ts
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+
+import { Image } from 'ember-osf-web/models/binderhub-config';
+
+interface Args {
+    image: Image;
+    showImageURL: (imageReference: string) => boolean;
+    checked: boolean;
+    isSelectionAllowed: boolean;
+    isSelecting: boolean;
+    onButtonClick: () => void;
+}
+
+export default class BaseImageEntry extends Component<Args> {
+    get isImageURLVisible() {
+        return this.args.showImageURL(this.args.image.url);
+    }
+}

--- a/app/guid-node/binderhub/-components/project-editor/base-image-entry/styles.scss
+++ b/app/guid-node/binderhub/-components/project-editor/base-image-entry/styles.scss
@@ -9,10 +9,17 @@
     font-size: 1.25em;
 }
 
+.url {
+    color: #888;
+    font-size: 0.75em;
+    margin: 0 2em;
+}
+
 .description {
     color: #888;
 }
 
 .select_button {
     margin-left: auto;
+    min-width: max-content;
 }

--- a/app/guid-node/binderhub/-components/project-editor/base-image-entry/template.hbs
+++ b/app/guid-node/binderhub/-components/project-editor/base-image-entry/template.hbs
@@ -3,10 +3,9 @@
         <div local-class='name'>
             {{@image.name}}
             {{#if @checked}}
-                <i class='fa fa-check'
-                   data-test-image-selected={{@image.url}}
-                />
+                <i class='fa fa-check' data-test-image-selected={{@image.url}}/>
             {{/if}}
+            <span local-class='url'>{{@image.url}}</span>
         </div>
         <div local-class='description'>{{@image.description}}</div>
     </div>
@@ -17,7 +16,7 @@
                     data-test-image-selection={{@image.url}}
                     type='button'
                     class='btn btn-default'
-                    {{on 'click' @onButtonClick}}
+                    onClick={{@onButtonClick}}
                     >
                     {{t 'binderhub.deployment.select_environment'}}
                 </button>
@@ -26,7 +25,7 @@
                     data-test-image-change={{@image.url}}
                     type='button'
                     class='btn btn-default'
-                    {{on 'click' @onButtonClick}}
+                    onClick={{@onButtonClick}}
                     >
                     {{t 'binderhub.deployment.change_environment'}}
                 </button>

--- a/app/guid-node/binderhub/-components/project-editor/base-image-entry/template.hbs
+++ b/app/guid-node/binderhub/-components/project-editor/base-image-entry/template.hbs
@@ -5,7 +5,9 @@
             {{#if @checked}}
                 <i class='fa fa-check' data-test-image-selected={{@image.url}}/>
             {{/if}}
-            <span local-class='url'>{{@image.url}}</span>
+            {{#if this.isImageURLVisible}}
+                <span local-class='url'>{{@image.url}}</span>
+            {{/if}}
         </div>
         <div local-class='description'>{{@image.description}}</div>
     </div>

--- a/app/guid-node/binderhub/-components/project-editor/component.ts
+++ b/app/guid-node/binderhub/-components/project-editor/component.ts
@@ -1483,6 +1483,11 @@ export default class ProjectEditor extends Component {
     }
 
     @action
+    showImageReference(this: ProjectEditor, imageReference: string) {
+        return !(imageReference.startsWith('!') && imageReference.endsWith('!'));
+    }
+
+    @action
     selectImage(this: ProjectEditor, url: string) {
         if (this.get('selectedImageUrl') !== this.get('singlespeedImage').url) {
             this.set('imageSelecting', false);

--- a/app/guid-node/binderhub/-components/project-editor/component.ts
+++ b/app/guid-node/binderhub/-components/project-editor/component.ts
@@ -3,6 +3,7 @@ import EmberError from '@ember/error';
 import { action, computed } from '@ember/object';
 import { later } from '@ember/runloop';
 import { inject as service } from '@ember/service';
+import DS from 'ember-data';
 import Intl from 'ember-intl/services/intl';
 import { requiredAction } from 'ember-osf-web/decorators/component';
 import {
@@ -11,12 +12,13 @@ import {
     isBinderHubConfigFulfilled,
 } from 'ember-osf-web/guid-node/binderhub/controller';
 import BinderHubConfigModel, { Image } from 'ember-osf-web/models/binderhub-config';
+import CustomBaseImageModel from 'ember-osf-web/models/custom-base-image';
 import Node from 'ember-osf-web/models/node';
 import CurrentUser from 'ember-osf-web/services/current-user';
 import { WaterButlerFile } from 'ember-osf-web/utils/waterbutler/base';
 import md5 from 'js-md5';
 
-const REPO2DOCKER_IMAGE_ID = '#repo2docker';
+export const REPO2DOCKER_IMAGE_ID = '#repo2docker';
 
 enum DockerfileProperty {
     From,
@@ -29,6 +31,19 @@ enum DockerfileProperty {
     Mpm,
     PostBuild,
     NoChanges,
+}
+
+function imageFromCustomBaseImageModel(model: CustomBaseImageModel) {
+    return {
+        url: model.imageReference,
+        name: model.name,
+        description: '',
+        description_ja: model.descriptionJa,
+        description_en: model.descriptionEn,
+        packages: [],
+        deprecated: model.deprecated,
+        recommended: false,
+    };
 }
 
 function getAptPackageId(pkg: string[]) {
@@ -156,7 +171,8 @@ interface EnvironmentDependencies {
 }
 
 enum ImageCategory {
-    CUSTOM = 'CUSTOM',
+    SINGLESPEED = 'SINGLESPEED',
+    USER = 'USER',
     PREFERRED = 'PREFERRED',
     DEPRECATED = 'DEPRECATED',
 }
@@ -166,11 +182,17 @@ export default class ProjectEditor extends Component {
 
     @service intl!: Intl;
 
+    @service store!: DS.Store;
+
     node?: Node | null = null;
 
     binderHubConfig!: BinderHubConfigModel;
 
     configFolder: WaterButlerFile = this.configFolder;
+
+    initialCustomBaseImages: CustomBaseImageModel[] = [];
+
+    dyCustomBaseImageModels: CustomBaseImageModel[] = [];
 
     dockerfileModel: WaterButlerFile | null = this.dockerfileModel;
 
@@ -214,7 +236,7 @@ export default class ProjectEditor extends Component {
 
     mranVersionSettingError = false;
 
-    customImage!: Image;
+    singlespeedImage!: Image;
 
     isInitialized: boolean = false;
 
@@ -244,14 +266,25 @@ export default class ProjectEditor extends Component {
         callback: (result: BuildMessage) => void,
     ) => void;
 
+    deletingCustomBaseImageModel?: CustomBaseImageModel = undefined;
+
     didReceiveAttrs() {
         if (!this.configFolder || this.configFolder.path === this.loadingPath) {
             return;
         }
         this.loadingPath = this.configFolder.path;
 
-        this.set('customImage', {
-            url: 'custom',
+        if (!this.initialCustomBaseImages) {
+            return;
+        }
+
+        this.set(
+            'dyCustomBaseImageModels',
+            this.initialCustomBaseImages.toArray(),
+        );
+
+        this.set('singlespeedImage', {
+            url: '!SINGLESPEED!',
             name: this.intl.t('binderhub.deployment.custom_image_name'),
             description: this.intl.t('binderhub.deployment.custom_image_description'),
             packages: [],
@@ -262,7 +295,7 @@ export default class ProjectEditor extends Component {
         later(async () => {
             try {
                 await this.loadCurrentConfig();
-                if (this.selectedImageUrl !== this.get('customImage').url) {
+                if (this.selectedImageUrl !== this.get('singlespeedImage').url) {
                     // All the configuration files should be left as-is
                     // if the custom image is selected. Currently, we
                     // cannot expect the introduction of other images
@@ -275,6 +308,44 @@ export default class ProjectEditor extends Component {
                 this.onError(exception, this.intl.t('binderhub.error.load_files_error'));
             }
         }, 0);
+    }
+
+    @action
+    pickDeleteTarget(target?: CustomBaseImageModel) {
+        this.set('deletingCustomBaseImageModel', target);
+    }
+
+    @action
+    async deleteCustomBaseImageModel(target: CustomBaseImageModel) {
+        this.set('deletingCustomBaseImageModel', undefined);
+        const node = this.get('node');
+        if (!node) {
+            throw new EmberError('Illegal state. The node object is not set.');
+        }
+
+        const result = await target.destroyRecord({ adapterOptions: { guid: node.id } });
+
+        if (result) {
+            if (target.imageReference === this.get('selectedImageUrl')) {
+                await this.saveCurrentConfig(
+                    this.buildDockerfileSetInstruction('', false),
+                );
+            }
+            await this.reloadCustomBaseImageModels(true);
+        }
+    }
+
+    @action
+    async reloadCustomBaseImageModels(peek: boolean) {
+        const node = this.get('node');
+        if (!node) {
+            throw new EmberError('Illegal state. The node object is not set.');
+        }
+
+        const latest = peek ? await this.store.peekAll('custom-base-image')
+            : await this.store.query('custom-base-image', { guid: node.id, includeParentImages: true });
+
+        this.set('dyCustomBaseImageModels', latest.toArray());
     }
 
     @computed('configFolder', 'dockerfile', 'isInitialized')
@@ -387,13 +458,14 @@ export default class ProjectEditor extends Component {
     }
 
     decideImageCategory(image: Image): ImageCategory {
-        if (image.url === this.customImage.url) {
-            return ImageCategory.CUSTOM;
+        if (image.url === this.singlespeedImage.url) {
+            return ImageCategory.SINGLESPEED;
         }
-        if (image.deprecated) {
-            return ImageCategory.DEPRECATED;
+        const deployment = this.get('deployment');
+        if (deployment && deployment.images.some(({ url }) => url === image.url)) {
+            return image.deprecated ? ImageCategory.DEPRECATED : ImageCategory.PREFERRED;
         }
-        return ImageCategory.PREFERRED;
+        return ImageCategory.USER;
     }
 
     getUpdatedDockerfile(key: DockerfileProperty, value: string) {
@@ -623,18 +695,23 @@ export default class ProjectEditor extends Component {
         }
 
         if (this.checkEmptyScript(dockerfile) || this.verifyHashHeader(dockerfile)) {
-            return this.get('customImage').url;
+            return this.get('singlespeedImage').url;
         }
         const fromStatements = dockerfile.split('\n')
             .filter(line => line.match(/^FROM\s+\S+\s*/));
         if (fromStatements.length === 0) {
-            return this.get('customImage').url;
+            return this.get('singlespeedImage').url;
         }
         const fromStatement = fromStatements[0].match(/^FROM\s+(\S+)\s*/);
         if (!fromStatement) {
-            return this.get('customImage').url;
+            return this.get('singlespeedImage').url;
         }
         return fromStatement[1];
+    }
+
+    @computed('dyCustomBaseImageModels')
+    get ownedCustomBaseImageModels() {
+        return this.get('dyCustomBaseImageModels').filter(({ level }) => level === 0);
     }
 
     @computed('deployment')
@@ -642,6 +719,10 @@ export default class ProjectEditor extends Component {
         const deployment = this.get('deployment');
         if (!deployment) {
             throw new EmberError('Illegal config. No deployment images are offered.');
+        }
+        const node = this.get('node');
+        if (!node) {
+            throw new EmberError('Illegal state. The node object is not set.');
         }
         return deployment.images.reduce(({ preferred, deprecated }, image) => {
             if (image.deprecated) {
@@ -657,12 +738,22 @@ export default class ProjectEditor extends Component {
         }, { preferred: [], deprecated: [] });
     }
 
+    @computed('deployment', 'ownedCustomBaseImageModels')
+    get ownedImageRefs() {
+        const deployment = this.get('deployment');
+        return [
+            ...(deployment ? deployment.images.map(({ url }) => url) : []),
+            this.singlespeedImage.url,
+            ...this.get('ownedCustomBaseImageModels').map(({ imageReference }) => imageReference),
+        ];
+    }
+
     @computed('selectedImage')
     get modifiedSelectedImage(): Image {
         return this.modifyImageForLocale(this.get('selectedImage'));
     }
 
-    @computed('selectedImageUrl', 'deployment', 'customImage')
+    @computed('selectedImageUrl', 'deployment', 'singlespeedImage', 'dyCustomBaseImageModels')
     get selectedImage(): Image {
         const url = this.get('selectedImageUrl');
         if (url === null) {
@@ -676,9 +767,13 @@ export default class ProjectEditor extends Component {
         if (!deployment) {
             throw new EmberError('Illegal config. No deployment images are offered.');
         }
-        const image = [...deployment.images, this.customImage].find(img => img.url === url);
+        const image = [
+            ...deployment.images,
+            ...this.get('dyCustomBaseImageModels').map(imageFromCustomBaseImageModel),
+            this.singlespeedImage,
+        ].find(img => img.url === url);
         if (!image) {
-            throw new EmberError(`Undefined image: ${url}`);
+            return this.singlespeedImage;
         }
         return image;
     }
@@ -700,13 +795,15 @@ export default class ProjectEditor extends Component {
 
     @computed('selectedImage')
     get isDockerfileEditorVisible() {
-        return this.isInitialized && this.decideImageCategory(this.get('selectedImage')) === ImageCategory.CUSTOM;
+        return this.isInitialized && this.decideImageCategory(this.get('selectedImage')) === ImageCategory.SINGLESPEED;
     }
 
     @computed('selectedImage')
     get isPackageEditorVisible(): boolean {
         const image = this.get('selectedImage');
-        return image && this.decideImageCategory(image) !== ImageCategory.CUSTOM;
+        return image
+        && this.decideImageCategory(image) !== ImageCategory.SINGLESPEED
+        && this.decideImageCategory(image) !== ImageCategory.USER;
     }
 
     @computed('selectedImage')
@@ -1327,11 +1424,11 @@ export default class ProjectEditor extends Component {
 
     async performResetDirtyFragileFiles() {
         const files = this.get('dirtyFragileConfigFiles');
-        await Promise.all(files.map(file => this.performResetDirtyFragileFile(file)));
+        await Promise.all(files.map(file => this.performResetFile(file)));
         window.location.reload();
     }
 
-    async performResetDirtyFragileFile(configFile: ConfigurationFile) {
+    async performResetFile(configFile: ConfigurationFile) {
         const fileModel = this.get(configFile.modelProperty);
         if (!fileModel) {
             throw new EmberError('Illegal config');
@@ -1387,7 +1484,7 @@ export default class ProjectEditor extends Component {
 
     @action
     selectImage(this: ProjectEditor, url: string) {
-        if (this.get('selectedImageUrl') !== this.get('customImage').url) {
+        if (this.get('selectedImageUrl') !== this.get('singlespeedImage').url) {
             this.set('imageSelecting', false);
             this.set('showDeprecated', false);
             this.set('pendingImageUrl', undefined);
@@ -1395,6 +1492,20 @@ export default class ProjectEditor extends Component {
         } else {
             this.set('pendingImageUrl', url);
         }
+    }
+
+    @action
+    selectCustomBaseImage(this: ProjectEditor, imageReference: string) {
+        this.set('imageSelecting', false);
+        this.set('showDeprecated', false);
+        this.set('pendingImageUrl', undefined);
+        later(async () => {
+            const files = this.get('configurationFiles').filter(file => (
+                file.name !== 'Dockerfile' && this.get(file.modelProperty)
+            ));
+            await Promise.all(files.map(file => this.performResetFile(file)));
+            this.updateFiles(DockerfileProperty.From, imageReference);
+        }, 0);
     }
 
     @action
@@ -1411,10 +1522,10 @@ export default class ProjectEditor extends Component {
     }
 
     @action
-    selectCustomImage(this: ProjectEditor) {
+    selectSinglespeedImage(this: ProjectEditor) {
         this.set('imageSelecting', false);
         this.set('showDeprecated', false);
-        if (this.get('selectedImageUrl') !== this.get('customImage').url) {
+        if (this.get('selectedImageUrl') !== this.get('singlespeedImage').url) {
             later(async () => (
                 this.saveCurrentConfig(
                     this.buildDockerfileSetInstruction('', false),
@@ -1606,5 +1717,10 @@ export default class ProjectEditor extends Component {
             image.description = image.description_en;
         }
         return image;
+    }
+
+    @action
+    modifyCustomBaseImageModelForLocale(model: CustomBaseImageModel) {
+        return this.modifyImageForLocale(imageFromCustomBaseImageModel(model));
     }
 }

--- a/app/guid-node/binderhub/-components/project-editor/custom-base-image-dialogue/component.ts
+++ b/app/guid-node/binderhub/-components/project-editor/custom-base-image-dialogue/component.ts
@@ -1,0 +1,233 @@
+import EmberError from '@ember/error';
+import { action } from '@ember/object';
+import { later } from '@ember/runloop';
+import { inject as service } from '@ember/service';
+
+import DS from 'ember-data';
+import { ConflictError, InvalidError } from 'ember-data/adapters/errors';
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import { Image } from 'ember-osf-web/models/binderhub-config';
+import CustomBaseImageModel from 'ember-osf-web/models/custom-base-image';
+
+import { REPO2DOCKER_IMAGE_ID } from 'ember-osf-web/guid-node/binderhub/-components/project-editor/component';
+
+type StringFiledName = 'name' | 'imageReference' | 'descriptionJa' | 'descriptionEn';
+
+interface Args {
+    guid: string;
+    ownedImageRefs: string[];
+    requestCustomBaseImageReloading: (peek: boolean) => void;
+    customBaseImageModels: CustomBaseImageModel[];
+    modelConverter: (model: CustomBaseImageModel) => Image;
+}
+
+// Although Crypto does offers `randomUUID` function, the TypeScript
+// compiler does not allow us to use it. The type definition might lack
+// the entry for that function. This is a workaround to utilize the
+// function. Moreover, the linter raises a parsing error for the
+// optional chaining operator (?.)  even though the TypeScript compiler
+// never complains about it.
+function generateUUID(fallback: string) {
+    if (typeof self.crypto !== 'undefined') {
+        const c = self.crypto as { randomUUID?(): string; };
+        if (c.randomUUID) {
+            return c.randomUUID() || fallback;
+        }
+    }
+    return fallback;
+}
+
+// Base Images and Custom Base Images are simply called `Image` and the
+// former ones are handled via Image class, while the latter ones are
+// handled via CustomBaseImageModel.
+export default class CustomBaseImageDialogue extends Component<Args> {
+    @service store!: DS.Store;
+
+    @tracked name: string = '';
+
+    @tracked imageReference: string = '';
+
+    @tracked descriptionJa: string = '';
+
+    @tracked descriptionEn: string = '';
+
+    @tracked deprecated: boolean = false;
+
+    @tracked dialogueOpenBit: boolean = false;
+
+    @tracked referenceInUseBit: boolean = false;
+
+    @tracked mandatoryFieldEmptyBit: boolean = false;
+
+    @tracked repo2dockerSubmittedBit: boolean = false;
+
+    @tracked showSuccessMsgBit: boolean = false;
+
+    @tracked lastImageName: string = '';
+
+    @tracked lastImageReference: string = '';
+
+    timeoutID: ReturnType<typeof setTimeout> | null = null;
+
+    createNewCustomBaseImageTabEelementID: string = generateUUID('create_new_custom_base_image_tab');
+
+    @action
+    updateOpenBit(openBit: boolean) {
+        this.dialogueOpenBit = openBit;
+    }
+
+    @action
+    updateStringField(fieldName: StringFiledName, event: { target: HTMLInputElement }) {
+        this[fieldName] = event.target.value;
+    }
+
+    @action
+    registerCustomBaseImage() {
+        const imgRef = this.imageReference.trim();
+        if (this.name.length === 0 || imgRef.length === 0) {
+            this.mandatoryFieldEmptyBit = true;
+            this.referenceInUseBit = false;
+            this.repo2dockerSubmittedBit = false;
+            this.lastImageName = '';
+            this.showSuccessMsgBit = false;
+            return;
+        }
+        if (this.args.ownedImageRefs.includes(imgRef)) {
+            this.referenceInUseBit = true;
+            this.lastImageReference = imgRef;
+            this.mandatoryFieldEmptyBit = false;
+            this.repo2dockerSubmittedBit = false;
+            this.lastImageName = '';
+            this.showSuccessMsgBit = false;
+            return;
+        }
+        if (imgRef.startsWith(REPO2DOCKER_IMAGE_ID)) {
+            this.repo2dockerSubmittedBit = true;
+            this.referenceInUseBit = false;
+            this.lastImageReference = '';
+            this.mandatoryFieldEmptyBit = false;
+            this.lastImageName = '';
+            this.showSuccessMsgBit = false;
+        }
+        if (this.timeoutID !== null) {
+            clearTimeout(this.timeoutID);
+        }
+        later(async () => {
+            try {
+                await this.createCustomBaseImage(
+                    this.name, imgRef, this.descriptionJa, this.descriptionEn,
+                );
+                this.showSuccessMsgBit = true;
+                this.lastImageName = this.name;
+                await this.args.requestCustomBaseImageReloading(true);
+                this.clearFields();
+                this.timeoutID = setTimeout(() => {
+                    this.showSuccessMsgBit = false;
+                    this.lastImageName = '';
+                    this.timeoutID = null;
+                }, 5000);
+            } catch (e) {
+                this.showSuccessMsgBit = false;
+                await this.args.requestCustomBaseImageReloading(false);
+                // Just rethrow `e` here since it already has the
+                // detailed message. `createCustomBaseImage` method did
+                // the job.
+                throw e;
+            }
+        }, 0);
+    }
+
+    @action
+    inheritCustomBaseImage(model: CustomBaseImageModel, changeTab: () => void) {
+        this.name = model.name;
+        this.imageReference = model.imageReference;
+        this.descriptionJa = model.descriptionJa;
+        this.descriptionEn = model.descriptionEn;
+        changeTab();
+    }
+
+    isInheritable(model: CustomBaseImageModel) {
+        return !this.args.ownedImageRefs.includes(model.imageReference);
+    }
+
+    async createCustomBaseImage(name: string, imageReference: string, descriptionJa: string, descriptionEn: string) {
+        try {
+            await this.store.createRecord(
+                'custom-base-image',
+                {
+                    name,
+                    imageReference,
+                    descriptionJa,
+                    descriptionEn,
+                    deprecated: false,
+                },
+            ).save({ adapterOptions: { guid: this.args.guid } });
+        } catch (e) {
+            if (e instanceof ConflictError) {
+                throw new EmberError(
+                    'Failed to create a new Custom Base Image since the requested entry already exists.',
+                );
+            }
+            if (e instanceof InvalidError) {
+                throw new EmberError(
+                    'Failed to create a new Custom Base Image since one or more non-empty fields was empty.',
+                );
+            }
+            throw new EmberError('Failed to create a custom base image for an unknown reason.');
+        }
+    }
+
+    get ancestorImageModelHashSeq() {
+        const modelHash = this.args.customBaseImageModels.filter(
+            ({ guid }) => guid !== this.args.guid,
+        ).reduce((acc, model) => {
+            if (typeof acc[model.guid] === 'undefined') {
+                acc[model.guid] = {
+                    guid: model.guid,
+                    level: model.level,
+                    title: model.nodeTitle,
+                    modelInfos: [],
+                };
+            }
+            acc[model.guid].modelInfos.push({
+                model,
+                inheritable: this.isInheritable(model),
+            });
+            return acc;
+        }, {} as {
+            [key: string]: {
+                guid: string,
+                level: number,
+                title: string,
+                modelInfos: Array<{ model: CustomBaseImageModel, inheritable: boolean }>,
+            },
+        });
+        return Object.values(modelHash).sort((x, y) => x.level - y.level);
+    }
+
+    clearFields() {
+        // TODO: use StringFiledName type effectively.
+        this.name = '';
+        this.imageReference = '';
+        this.descriptionJa = '';
+        this.descriptionEn = '';
+        this.referenceInUseBit = false;
+        this.lastImageReference = '';
+        this.mandatoryFieldEmptyBit = false;
+    }
+
+    @action
+    onClose() {
+        this.updateOpenBit(false);
+        this.showSuccessMsgBit = false;
+        if (this.timeoutID !== null) {
+            clearTimeout(this.timeoutID);
+        }
+        this.lastImageReference = '';
+        this.referenceInUseBit = false;
+        this.mandatoryFieldEmptyBit = false;
+    }
+}

--- a/app/guid-node/binderhub/-components/project-editor/custom-base-image-dialogue/styles.scss
+++ b/app/guid-node/binderhub/-components/project-editor/custom-base-image-dialogue/styles.scss
@@ -1,0 +1,77 @@
+.create_button {
+    margin-left: auto;
+    border-style: none;
+    border-radius: 5px;
+    background-color: #fff;
+}
+
+.header {
+    display: flex;
+}
+
+.message {
+    margin: 0 10px 0 auto;
+    border-radius: 5px;
+    padding: 0.5em;
+    max-width: 50%;
+    background-color: #98fb98;
+}
+
+.accept_message {
+    color: none;
+}
+
+.attention {
+    padding: 2px;
+}
+
+.caution_message {
+    color: #ff8484;
+}
+
+.image_listing_pane {
+    max-height: 60vh;
+    overflow-y: scroll;
+}
+
+.input_label_span {
+    margin-left: auto;
+}
+
+.short_input_textarea {
+    resize: none;
+    width: 70%;
+    margin-left: auto;
+}
+
+.short_input_label {
+    display: flex;
+    align-items: center;
+}
+
+.long_input_label {
+    width: 100%;
+}
+
+.register_button_area {
+    display: flex;
+}
+
+.register_button {
+    margin: 15px 15px 15px auto;
+}
+
+.node_title {
+    font-size: 1em;
+    font-weight: bold;
+}
+
+.inheritable_image_entry {
+    margin: 0.5em;
+}
+
+.disabled_image_entry {
+    margin: 0.5em;
+    opacity: 0.6;
+    pointer-events: none;
+}

--- a/app/guid-node/binderhub/-components/project-editor/custom-base-image-dialogue/template.hbs
+++ b/app/guid-node/binderhub/-components/project-editor/custom-base-image-dialogue/template.hbs
@@ -1,0 +1,140 @@
+<BsButton local-class='create_button' onClick={{fn this.updateOpenBit true}}>
+    {{t 'binderhub.deployment.custom_base_image.dialogue.title'}}
+</BsButton>
+
+<BsModal @open={{this.dialogueOpenBit}} @onHide={{this.onClose}} as |modal|>
+    <modal.header>
+        <div local-class='header'>
+            <h4>
+                {{t 'binderhub.deployment.custom_base_image.dialogue.title'}}
+            </h4>
+            {{#if this.showSuccessMsgBit}}
+                <div local-class='message'>
+                    <span local-class='accept_message'>
+                        {{t 'binderhub.deployment.custom_base_image.dialogue.registration_succeeded'
+                        name=this.lastImageName}}
+                    </span>
+                </div>
+            {{/if}}
+        </div>
+    </modal.header>
+    <BsTab as |tab|>
+        <tab.pane local-class='image_listing_pane'
+            @elementId={{this.createNewCustomBaseImageTabEelementID}}
+            @title={{t 'binderhub.deployment.custom_base_image.dialogue.create_new'}}>
+            <modal.body>
+                <div local-class='attention'>
+                    {{t 'binderhub.deployment.custom_base_image.dialogue.information'}}
+                </div>
+                {{#if this.referenceInUseBit}}
+                    <div>
+                        <span local-class='caution_message'>
+                            {{t
+                                'binderhub.deployment.custom_base_image.dialogue.already_in_use'
+                                imageReference=this.lastImageReference
+                            }}
+                        </span>
+                    </div>
+                {{/if}}
+                {{#if this.mandatoryFieldEmptyBit}}
+                    <div>
+                        <span local-class='caution_message'>
+                            {{t 'binderhub.deployment.custom_base_image.dialogue.mandatory_field'}}
+                        </span>
+                    </div>
+                {{/if}}
+                {{#if this.repo2dockerSubmittedBit}}
+                    <div>
+                        <span local-class='caution_message'>
+                            {{t 'binderhub.deployment.custom_base_image.dialogue.repo2docker'}}
+                        </span>
+                    </div>
+                {{/if}}
+                <div>
+                    <form>
+                        <label local-class='short_input_label'>
+                            <span local-class='input_label_span'>
+                                {{t 'binderhub.deployment.custom_base_image.dialogue.name_label'}}
+                            </span>
+                            <textarea
+                                class='form-control'
+                                local-class='short_input_textarea'
+                                rows='1'
+                                value={{this.name}}
+                                {{on 'keyup' (fn this.updateStringField 'name')}}
+                                />
+                        </label>
+                        <label local-class='short_input_label'>
+                            <span local-class='input_label_span'>
+                                {{t 'binderhub.deployment.custom_base_image.dialogue.reference_label'}}
+                            </span>
+                            <textarea
+                                class='form-control'
+                                local-class='short_input_textarea'
+                                rows='1'
+                                value={{this.imageReference}}
+                                {{on 'keyup' (fn this.updateStringField 'imageReference')}}
+                                />
+                        </label>
+                        <label local-class='long_input_label'>
+                            <span>
+                                {{t 'binderhub.deployment.custom_base_image.dialogue.description_ja_label'}}
+                            </span>
+                            <textarea
+                                class='form-control'
+                                rows='2'
+                                value={{this.descriptionJa}}
+                                {{on 'keyup' (fn this.updateStringField 'descriptionJa')}}
+                                />
+                        </label>
+                        <label local-class='long_input_label'>
+                            <span>
+                                {{t 'binderhub.deployment.custom_base_image.dialogue.description_en_label'}}
+                            </span>
+                            <textarea
+                                class='form-control'
+                                rows='2'
+                                value={{this.descriptionEn}}
+                                {{on 'keyup' (fn this.updateStringField 'descriptionEn')}}
+                                />
+                        </label>
+                    </form>
+                </div>
+            </modal.body>
+            <div local-class='register_button_area'>
+                <BsButton
+                    @type='success'
+                    local-class='register_button'
+                    onClick={{this.registerCustomBaseImage}}>
+                    {{t 'binderhub.deployment.custom_base_image.dialogue.register_button_label'}}
+                </BsButton>
+            </div>
+        </tab.pane>
+        <tab.pane local-class='image_listing_pane'
+            @title={{t 'binderhub.deployment.custom_base_image.dialogue.inherit'}}>
+            {{#if this.ancestorImageModelHashSeq}}
+                {{#each this.ancestorImageModelHashSeq as |hash|}}
+                    <h3>[{{get hash 'guid'}}] <span local-class='node_title'>{{get hash 'title'}}</span></h3>
+                    {{#each (get hash 'modelInfos') as |info|}}
+                        <GuidNode::Binderhub::-Components::ProjectEditor::CustomBaseImageEntry
+                            local-class={{if (get info 'inheritable') 'inheritable_image_entry' 'disabled_image_entry'}}
+                            @guid={{@guid}}
+                            @target={{get info 'model'}}
+                            @localizer={{@modelConverter}}
+                            @checked={{false}}
+                            @selectButtonTitle={{t 'binderhub.deployment.custom_base_image.dialogue.obtain_button'}}
+                            @isSelectionAllowed={{get info 'inheritable'}}
+                            @onButtonClick={{
+                                fn this.inheritCustomBaseImage (get info 'model')
+                                (fn tab.select this.createNewCustomBaseImageTabEelementID)
+                            }}
+                            @requestCustomBaseImageReloading={{@requestCustomBaseImageReloading}}
+                        />
+                    {{/each}}
+                {{/each}}
+            {{else}}
+                <h4>{{t 'binderhub.deployment.custom_base_image.dialogue.no_relevants'}}</h4>
+            {{/if}}
+        </tab.pane>
+    </BsTab>
+</BsModal>

--- a/app/guid-node/binderhub/-components/project-editor/custom-base-image-entry/component.ts
+++ b/app/guid-node/binderhub/-components/project-editor/custom-base-image-entry/component.ts
@@ -1,0 +1,45 @@
+import { action } from '@ember/object';
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import { Image } from 'ember-osf-web/models/binderhub-config';
+import CustomBaseImageModel from 'ember-osf-web/models/custom-base-image';
+
+interface Args {
+    guid: string;
+    target: CustomBaseImageModel;
+    localizer: (model: CustomBaseImageModel) => Image;
+    checked: boolean;
+    isSelectionAllowed: boolean;
+    isSelecting: boolean;
+    onButtonClick: () => void;
+    onDeleteClick?: () => void;
+    requestCustomBaseImageReloading: (peek: boolean) => void;
+}
+
+export default class CustomBaseImageEntry extends Component<Args> {
+    @tracked editorOpenBit: boolean = false;
+
+    @tracked editFatalFailuerBit: boolean = false;
+
+    @action
+    updateEditorOpenBit(openBit: boolean) {
+        this.editorOpenBit = openBit;
+    }
+
+    get description() {
+        return this.args.localizer(this.args.target).description;
+    }
+
+    @action
+    updateFatalFailureBit(bit: boolean) {
+        this.editFatalFailuerBit = bit;
+    }
+
+    @action
+    closeFatalDialogue() {
+        this.args.requestCustomBaseImageReloading(false);
+        this.updateFatalFailureBit(false);
+    }
+}

--- a/app/guid-node/binderhub/-components/project-editor/custom-base-image-entry/component.ts
+++ b/app/guid-node/binderhub/-components/project-editor/custom-base-image-entry/component.ts
@@ -10,6 +10,7 @@ interface Args {
     guid: string;
     target: CustomBaseImageModel;
     localizer: (model: CustomBaseImageModel) => Image;
+    showImageReference: (imageReference: string) => boolean;
     checked: boolean;
     isSelectionAllowed: boolean;
     isSelecting: boolean;
@@ -30,6 +31,10 @@ export default class CustomBaseImageEntry extends Component<Args> {
 
     get description() {
         return this.args.localizer(this.args.target).description;
+    }
+
+    get isImageReferenceVisible() {
+        return this.args.showImageReference(this.args.target.imageReference);
     }
 
     @action

--- a/app/guid-node/binderhub/-components/project-editor/custom-base-image-entry/styles.scss
+++ b/app/guid-node/binderhub/-components/project-editor/custom-base-image-entry/styles.scss
@@ -1,0 +1,47 @@
+.entry {
+    display: flex;
+    padding: 1em;
+    border-radius: 4px;
+    border: 1px solid #adadad;
+}
+
+.sub_button_menu {
+    min-width: min-content;
+    background-color: #f8f8f8;
+}
+
+.sub_button_item {
+    width: min-content;
+}
+
+.sub_button {
+    border-style: none;
+}
+
+.delete_icon {
+    width: 14px;
+    color: #b52b27;
+
+    &:hover {
+        color: #8b211e;
+    }
+}
+
+.name {
+    font-size: 1.25em;
+}
+
+.url {
+    color: #888;
+    font-size: 0.75em;
+    margin: 0 2em;
+}
+
+.description {
+    color: #888;
+}
+
+.select_button {
+    margin-left: auto;
+    min-width: max-content;
+}

--- a/app/guid-node/binderhub/-components/project-editor/custom-base-image-entry/template.hbs
+++ b/app/guid-node/binderhub/-components/project-editor/custom-base-image-entry/template.hbs
@@ -5,7 +5,9 @@
             {{#if @checked}}
                 <i class='fa fa-check' data-test-image-selected={{@target.imageReference}}/>
             {{/if}}
-            <span local-class='url'>{{@target.imageReference}}</span>
+            {{#if this.isImageReferenceVisible}}
+                <span local-class='url'>{{@target.imageReference}}</span>
+            {{/if}}
         </div>
         <div local-class='description'>{{this.description}}</div>
     </div>

--- a/app/guid-node/binderhub/-components/project-editor/custom-base-image-entry/template.hbs
+++ b/app/guid-node/binderhub/-components/project-editor/custom-base-image-entry/template.hbs
@@ -1,0 +1,76 @@
+<div data-test-custom-base-image local-class='entry' ...attributes>
+    <div>
+        <div local-class='name'>
+            {{@target.name}}
+            {{#if @checked}}
+                <i class='fa fa-check' data-test-image-selected={{@target.imageReference}}/>
+            {{/if}}
+            <span local-class='url'>{{@target.imageReference}}</span>
+        </div>
+        <div local-class='description'>{{this.description}}</div>
+    </div>
+    <div local-class='select_button'>
+        {{#if @isSelectionAllowed}}
+            {{#if @onDeleteClick}}
+                <BsDropdown data-test-image-pick={{@target.imageReference}} type='button' as |dd|>
+                    <dd.button data-test-more-menu>{{t 'binderhub.deployment.more_menu'}}</dd.button>
+                    <dd.menu local-class='sub_button_menu' as |menu|>
+                        <menu.item local-class='sub_button_item'>
+                            <BsButton data-test-edit-custom-base-image
+                                local-class='sub_button' type='button' onClick={{fn this.updateEditorOpenBit true}}>
+                                {{t 'general.edit'}}
+                                {{fa-icon 'edit' size=1}}
+                            </BsButton>
+                        </menu.item>
+                        <menu.item local-class='sub_button_item'>
+                            <BsButton data-test-delete-custom-base-image
+                                local-class='sub_button' type='button' onClick={{@onDeleteClick}}>
+                                {{t 'general.delete'}}
+                                {{fa-icon 'trash' size=1 local-class='delete_icon'}}
+                            </BsButton>
+                        </menu.item>
+                    </dd.menu>
+                </BsDropdown>
+            {{/if}}
+            <button
+                data-test-image-pick={{@target.imageReference}}
+                type='button'
+                class='btn btn-default'
+                onClick={{@onButtonClick}}
+                >
+                {{@selectButtonTitle}}
+            </button>
+        {{/if}}
+    </div>
+</div>
+
+<GuidNode::Binderhub::-Components::ProjectEditor::ImageEditor
+    @guid={{@guid}}
+    @target={{@target}}
+    @closeCallback={{fn this.updateEditorOpenBit false}}
+    @requestCustomBaseImageReloading={{@requestCustomBaseImageReloading}}
+    @openBit={{this.editorOpenBit}}
+    @onFatalFailure={{fn this.updateFatalFailureBit true}}
+    />
+
+<BsModal
+    @backdropClose={{false}}
+    @open={{this.editFatalFailuerBit}}
+    @onHide={{this.closeFatalDialogue}} as |modal|
+    >
+    <modal.header>
+        <div local-class='header'>
+            <h4>
+                {{t 'binderhub.deployment.custom_base_image.entry.fatal_title'}}
+            </h4>
+        </div>
+    </modal.header>
+    <modal.body>
+        {{t 'binderhub.deployment.custom_base_image.entry.fatal_message'}}
+    </modal.body>
+    <modal.footer>
+        <BsButton @type='danger' onClick={{this.closeFatalDialogue}}>
+            {{t 'general.ok'}}
+        </BsButton>
+    </modal.footer>
+</BsModal>

--- a/app/guid-node/binderhub/-components/project-editor/image-editor/component.ts
+++ b/app/guid-node/binderhub/-components/project-editor/image-editor/component.ts
@@ -1,0 +1,107 @@
+import EmberError from '@ember/error';
+import { action } from '@ember/object';
+import { later } from '@ember/runloop';
+import { inject as service } from '@ember/service';
+
+import DS from 'ember-data';
+import { InvalidError, NotFoundError } from 'ember-data/adapters/errors';
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import CustomBaseImageModel from 'ember-osf-web/models/custom-base-image';
+
+type StringFiledName = 'name' | 'descriptionJa' | 'descriptionEn';
+
+interface Args {
+    openBit: boolean;
+    guid: string;
+    target: CustomBaseImageModel;
+    closeCallback: () => void;
+    requestCustomBaseImageReloading: (peek: boolean) => void;
+    onFatalFailure: () => void;
+}
+
+export default class ImageEditor extends Component<Args> {
+    @service store!: DS.Store;
+
+    @tracked name: string = '';
+
+    @tracked descriptionJa: string = '';
+
+    @tracked descriptionEn: string = '';
+
+    @tracked mandatoryFieldEmptyBit: boolean = false;
+
+    @tracked showSuccessMsgBit: boolean = false;
+
+    timeoutID: ReturnType<typeof setTimeout> | null = null;
+
+    @action
+    init() {
+        this.name = this.args.target.name;
+        this.descriptionJa = this.args.target.descriptionJa;
+        this.descriptionEn = this.args.target.descriptionEn;
+    }
+
+    @action
+    updateStringField(fieldName: StringFiledName, event: { target: HTMLInputElement }) {
+        this[fieldName] = event.target.value;
+    }
+
+    @action
+    updateCustomBaseImage() {
+        if (this.name.length === 0) {
+            this.mandatoryFieldEmptyBit = true;
+            this.showSuccessMsgBit = false;
+            return;
+        }
+        if (this.timeoutID !== null) {
+            clearTimeout(this.timeoutID);
+        }
+        later(async () => {
+            try {
+                const { target, guid } = this.args;
+                target.name = this.name;
+                target.descriptionJa = this.descriptionJa;
+                target.descriptionEn = this.descriptionEn;
+                await target.save({ adapterOptions: { guid } });
+            } catch (e) {
+                this.showSuccessMsgBit = false;
+                if (e instanceof InvalidError) {
+                    await this.args.requestCustomBaseImageReloading(false);
+                    throw new EmberError(
+                        'Failed to update the custom base image since one or more non-empty filed is empty.',
+
+                    );
+                }
+                if (e instanceof NotFoundError) {
+                    this.onClose();
+                    this.args.onFatalFailure();
+                    throw new EmberError(
+                        'Failed to update. The specified custom base image does not exist.',
+
+                    );
+                }
+            }
+
+            this.showSuccessMsgBit = true;
+            await this.args.requestCustomBaseImageReloading(true);
+            this.mandatoryFieldEmptyBit = false;
+            this.timeoutID = setTimeout(() => {
+                this.showSuccessMsgBit = false;
+                this.timeoutID = null;
+            }, 5000);
+        }, 0);
+    }
+
+    @action
+    onClose() {
+        this.args.closeCallback();
+        this.showSuccessMsgBit = false;
+        if (this.timeoutID !== null) {
+            clearTimeout(this.timeoutID);
+        }
+        this.mandatoryFieldEmptyBit = false;
+    }
+}

--- a/app/guid-node/binderhub/-components/project-editor/image-editor/styles.scss
+++ b/app/guid-node/binderhub/-components/project-editor/image-editor/styles.scss
@@ -1,0 +1,68 @@
+.editor_open_button {
+    margin-left: auto;
+    border-style: none;
+    border-radius: 5px;
+    background-color: #fff;
+}
+
+.header {
+    display: flex;
+}
+
+.message {
+    margin: 0 10px 0 auto;
+    border-radius: 5px;
+    padding: 0.5em;
+    max-width: 50%;
+    background-color: #98fb98;
+}
+
+.accept_message {
+    color: none;
+}
+
+.caution_message {
+    color: #ff8484;
+}
+
+.input_label_span {
+    margin-left: auto;
+}
+
+.short_input_textarea {
+    resize: none;
+    width: 70%;
+    margin-left: auto;
+}
+
+.short_input_label {
+    display: flex;
+    align-items: center;
+}
+
+.long_input_label {
+    width: 100%;
+}
+
+.update_button_area {
+    display: flex;
+}
+
+.update_button {
+    margin: 15px 15px 15px auto;
+}
+
+.node_title {
+    font-size: 1em;
+    font-weight: bold;
+}
+
+.inheritable_image_entry {
+    margin: 0.5em;
+}
+
+.disabled_image_entry {
+    margin: 0.5em;
+    opacity: 0.6;
+    pointer-events: none;
+}

--- a/app/guid-node/binderhub/-components/project-editor/image-editor/template.hbs
+++ b/app/guid-node/binderhub/-components/project-editor/image-editor/template.hbs
@@ -1,0 +1,88 @@
+<BsModal @open={{@openBit}} {{did-insert this.init}} @onHide={{this.onClose}} as |modal|>
+    <modal.header>
+        <div local-class='header'>
+            <h4>
+                {{t 'binderhub.deployment.custom_base_image.editor.title'}}
+            </h4>
+            {{#if this.showSuccessMsgBit}}
+                <div local-class='message'>
+                    <span local-class='accept_message'>
+                        {{t 'binderhub.deployment.custom_base_image.editor.update_succeeded'
+                        name=this.lastImageName}}
+                    </span>
+                </div>
+            {{/if}}
+        </div>
+    </modal.header>
+    <modal.body>
+        {{#if this.mandatoryFieldEmptyBit}}
+            <div>
+                <span local-class='caution_message'>
+                    {{t 'binderhub.deployment.custom_base_image.editor.mandatory_field'}}
+                </span>
+            </div>
+        {{/if}}
+        <div>
+            <form>
+                <label local-class='short_input_label'>
+                    <span local-class='input_label_span'>
+                        {{t 'binderhub.deployment.custom_base_image.dialogue.name_label'}}
+                    </span>
+                    <textarea
+                        class='form-control'
+                        local-class='short_input_textarea'
+                        rows='1'
+                        value={{this.name}}
+                        onKeyUp={{fn this.updateStringField 'name'}}
+                        />
+                </label>
+                <label local-class='short_input_label'>
+                    <span local-class='input_label_span'>
+                        {{t 'binderhub.deployment.custom_base_image.dialogue.reference_label'}}
+                    </span>
+                    <textarea
+                        class='form-control'
+                        local-class='short_input_textarea'
+                        rows='1'
+                        readonly={{true}}
+                        value={{get @target 'imageReference'}}
+                        >
+                        <BsPopover @triggerEvents='hover'>
+                            {{t 'binderhub.deployment.custom_base_image.editor.image_reference_hint'}}
+                        </BsPopover>
+                    </textarea>
+                </label>
+                <label local-class='long_input_label'>
+                    <span>
+                        {{t 'binderhub.deployment.custom_base_image.dialogue.description_ja_label'}}
+                    </span>
+                    <textarea
+                        class='form-control'
+                        rows='2'
+                        value={{this.descriptionJa}}
+                        onKeyUp={{fn this.updateStringField 'descriptionJa'}}
+                        />
+                </label>
+                <label local-class='long_input_label'>
+                    <span>
+                        {{t 'binderhub.deployment.custom_base_image.dialogue.description_en_label'}}
+                    </span>
+                    <textarea
+                        class='form-control'
+                        rows='2'
+                        value={{this.descriptionEn}}
+                        onKeyUp={{fn this.updateStringField 'descriptionEn'}}
+                        />
+                </label>
+            </form>
+        </div>
+    </modal.body>
+    <div local-class='update_button_area'>
+        <BsButton
+            @type='success'
+            local-class='update_button'
+            onClick={{this.updateCustomBaseImage}}>
+            {{t 'binderhub.deployment.custom_base_image.editor.update_button_label'}}
+        </BsButton>
+    </div>
+</BsModal>

--- a/app/guid-node/binderhub/-components/project-editor/styles.scss
+++ b/app/guid-node/binderhub/-components/project-editor/styles.scss
@@ -1,4 +1,4 @@
-.basic_image_entry {
+.base_image_entry {
     margin: 0.5em;
 }
 
@@ -45,4 +45,8 @@
 .environment_setting_error {
     font-weight: bold;
     color: #f00;
+}
+
+.title_line {
+    display: flex;
 }

--- a/app/guid-node/binderhub/-components/project-editor/template.hbs
+++ b/app/guid-node/binderhub/-components/project-editor/template.hbs
@@ -25,12 +25,23 @@
                 </button>
             {{/if}}
         {{else}}
-            <h3>{{t 'binderhub.deployment.environment'}}</h3>
+            {{#if this.node.userHasWritePermission}}
+                <div local-class='title_line'>
+                    <h3>{{t 'binderhub.deployment.environment'}}</h3>
+                    <GuidNode::Binderhub::-Components::ProjectEditor::CustomBaseImageDialogue
+                        @guid={{this.node.id}}
+                        @ownedImageRefs={{this.ownedImageRefs}}
+                        @requestCustomBaseImageReloading={{this.reloadCustomBaseImageModels}}
+                        @customBaseImageModels={{this.dyCustomBaseImageModels}}
+                        @modelConverter={{this.modifyCustomBaseImageModelForLocale}}
+                    />
+                </div>
+            {{/if}}
             {{#if (or this.node.userHasWritePermission this.selectedImageUrl)}}
                 {{#if this.imageSelecting}}
                     {{#each this.selectableImages.preferred as |image|}}
-                        <GuidNode::Binderhub::-Components::ProjectEditor::BasicImageEntry
-                            local-class='basic_image_entry'
+                        <GuidNode::Binderhub::-Components::ProjectEditor::BaseImageEntry
+                            local-class='base_image_entry'
                             @image={{image}}
                             @checked={{eq this.selectedImageUrl image.url}}
                             @isSelectionAllowed={{this.node.userHasWritePermission}}
@@ -38,13 +49,27 @@
                             @onButtonClick={{fn this.selectImage image.url}}
                         />
                     {{/each}}
-                    <GuidNode::Binderhub::-Components::ProjectEditor::BasicImageEntry
-                        local-class='basic_image_entry'
-                        @image={{this.customImage}}
-                        @checked={{eq this.selectedImageUrl this.customImage.url}}
+                    {{#each this.ownedCustomBaseImageModels as |model|}}
+                        <GuidNode::Binderhub::-Components::ProjectEditor::CustomBaseImageEntry
+                            local-class='base_image_entry'
+                            @guid={{this.node.id}}
+                            @target={{model}}
+                            @localizer={{this.modifyCustomBaseImageModelForLocale}}
+                            @checked={{eq this.selectedImageUrl model.imageReference}}
+                            @selectButtonTitle={{t 'binderhub.deployment.select_environment'}}
+                            @isSelectionAllowed={{this.node.userHasWritePermission}}
+                            @onButtonClick={{fn this.selectCustomBaseImage model.imageReference}}
+                            @onDeleteClick={{fn this.pickDeleteTarget model}}
+                            @requestCustomBaseImageReloading={{this.reloadCustomBaseImageModels}}
+                        />
+                    {{/each}}
+                    <GuidNode::Binderhub::-Components::ProjectEditor::BaseImageEntry
+                        local-class='base_image_entry'
+                        @image={{this.singlespeedImage}}
+                        @checked={{eq this.selectedImageUrl this.singlespeedImage.url}}
                         @isSelectionAllowed={{this.node.userHasWritePermission}}
                         @isSelecting={{true}}
-                        @onButtonClick={{fn this.selectCustomImage}}
+                        @onButtonClick={{fn this.selectSinglespeedImage}}
                     />
                     <BsButton
                         data-test-deprecated-image-separator
@@ -60,8 +85,8 @@
                     </BsButton>
                     {{#if this.showDeprecated}}
                         {{#each this.selectableImages.deprecated as |image|}}
-                            <GuidNode::Binderhub::-Components::ProjectEditor::BasicImageEntry
-                                local-class='basic_image_entry'
+                            <GuidNode::Binderhub::-Components::ProjectEditor::BaseImageEntry
+                                local-class='base_image_entry'
                                 @image={{image}}
                                 @checked={{eq this.selectedImageUrl image.url}}
                                 @isSelectionAllowed={{this.node.userHasWritePermission}}
@@ -71,8 +96,8 @@
                         {{/each}}
                     {{/if}}
                 {{else}}
-                    <GuidNode::Binderhub::-Components::ProjectEditor::BasicImageEntry
-                        local-class='basic_image_entry'
+                    <GuidNode::Binderhub::-Components::ProjectEditor::BaseImageEntry
+                        local-class='base_image_entry'
                         @image={{this.modifiedSelectedImage}}
                         @checked={{true}}
                         @isSelectionAllowed={{this.node.userHasWritePermission}}
@@ -295,6 +320,32 @@
             @type='danger'
         >
             {{t 'general.ok'}}
+        </BsButton>
+    </modal.footer>
+</BsModal>
+
+<BsModal data-test-custom-base-image-delete-confirmation
+    @open={{this.deletingCustomBaseImageModel}}
+    @onHidden={{fn this.pickDeleteTarget undefined}} as |modal|
+>
+    <modal.header>
+        <h4>
+            {{t 'binderhub.deployment.custom_base_image.delete_confirmation.title'}}
+        </h4>
+    </modal.header>
+    <modal.body>
+        {{t 'binderhub.deployment.custom_base_image.delete_confirmation.content'}}
+    </modal.body>
+    <modal.footer>
+        <BsButton data-test-cancel-delete
+            @onClick={{fn this.pickDeleteTarget undefined}}>
+            {{t 'general.cancel'}}
+        </BsButton>
+        <BsButton data-test-do-delete-custom-base-image
+            @type='danger'
+            @onClick={{fn this.deleteCustomBaseImageModel this.deletingCustomBaseImageModel}}
+        >
+            {{t 'general.delete'}}
         </BsButton>
     </modal.footer>
 </BsModal>

--- a/app/guid-node/binderhub/-components/project-editor/template.hbs
+++ b/app/guid-node/binderhub/-components/project-editor/template.hbs
@@ -43,6 +43,7 @@
                         <GuidNode::Binderhub::-Components::ProjectEditor::BaseImageEntry
                             local-class='base_image_entry'
                             @image={{image}}
+                            @showImageURL={{this.showImageReference}}
                             @checked={{eq this.selectedImageUrl image.url}}
                             @isSelectionAllowed={{this.node.userHasWritePermission}}
                             @isSelecting={{true}}
@@ -55,6 +56,7 @@
                             @guid={{this.node.id}}
                             @target={{model}}
                             @localizer={{this.modifyCustomBaseImageModelForLocale}}
+                            @showImageReference={{this.showImageReference}}
                             @checked={{eq this.selectedImageUrl model.imageReference}}
                             @selectButtonTitle={{t 'binderhub.deployment.select_environment'}}
                             @isSelectionAllowed={{this.node.userHasWritePermission}}
@@ -66,6 +68,7 @@
                     <GuidNode::Binderhub::-Components::ProjectEditor::BaseImageEntry
                         local-class='base_image_entry'
                         @image={{this.singlespeedImage}}
+                        @showImageURL={{this.showImageReference}}
                         @checked={{eq this.selectedImageUrl this.singlespeedImage.url}}
                         @isSelectionAllowed={{this.node.userHasWritePermission}}
                         @isSelecting={{true}}
@@ -88,6 +91,7 @@
                             <GuidNode::Binderhub::-Components::ProjectEditor::BaseImageEntry
                                 local-class='base_image_entry'
                                 @image={{image}}
+                                @showImageURL={{this.showImageReference}}
                                 @checked={{eq this.selectedImageUrl image.url}}
                                 @isSelectionAllowed={{this.node.userHasWritePermission}}
                                 @isSelecting={{true}}
@@ -99,6 +103,7 @@
                     <GuidNode::Binderhub::-Components::ProjectEditor::BaseImageEntry
                         local-class='base_image_entry'
                         @image={{this.modifiedSelectedImage}}
+                        @showImageURL={{this.showImageReference}}
                         @checked={{true}}
                         @isSelectionAllowed={{this.node.userHasWritePermission}}
                         @isSelecting={{false}}

--- a/app/guid-node/binderhub/-components/project-editor/template.hbs
+++ b/app/guid-node/binderhub/-components/project-editor/template.hbs
@@ -178,10 +178,8 @@
                             @label='MATLAB (mpm)'
                             @url={{t 'binderhub.deployment.info_urls.mpm'}}
                             @config={{this.mpmConfig}}
+                            @availableReleases={{this.binderHubConfig.mpm_releases}}
                             @onUpdate={{action this.mpmUpdated}}
-                            @editing={{if (eq this.editingPackage 'mpm') 'editing'}}
-                            @onEditingStart={{action (mut this.editingPackage) 'mpm'}}
-                            @onEditingEnd={{action (mut this.editingPackage) ''}}
                         />
                     {{/if}}
                 </div>

--- a/app/guid-node/binderhub/-components/text-segment-highlight/styles.scss
+++ b/app/guid-node/binderhub/-components/text-segment-highlight/styles.scss
@@ -1,0 +1,3 @@
+.paint {
+    color: #f00;
+}

--- a/app/guid-node/binderhub/-components/text-segment-highlight/template.hbs
+++ b/app/guid-node/binderhub/-components/text-segment-highlight/template.hbs
@@ -1,0 +1,7 @@
+{{~#each @segmentHighlightMap as |entry|~}}
+    {{~#if entry.highlight~}}
+        <span local-class='paint'>{{~entry.segment~}}</span>
+    {{~else~}}
+        <span>{{~entry.segment~}}</span>
+    {{~/if~}}
+{{~/each~}}

--- a/app/guid-node/binderhub/-components/textfile-editor/template.hbs
+++ b/app/guid-node/binderhub/-components/textfile-editor/template.hbs
@@ -2,7 +2,7 @@
     <div local-class='title_line'>
         <h3>
             {{@title}}
-            <OsfButton @type='link' {{on 'click' this.flipEditorOpenBit}}>
+            <OsfButton @type='link' onClick={{this.flipEditorOpenBit}}>
                 {{#if this.editorOpenBit}}
                     {{fa-icon 'chevron-down'}}
                 {{else}}
@@ -26,7 +26,7 @@
                     type='button'
                     class='btn btn-default'
                     disabled={{not @enable}}
-                    {{on 'click' @onSave}}
+                    onClick={{@onSave}}
                 >
                     {{fa-icon 'save'}}
                     {{t 'binderhub.deployment.save_file'}}

--- a/app/guid-node/binderhub/errors.ts
+++ b/app/guid-node/binderhub/errors.ts
@@ -1,0 +1,9 @@
+/* eslint-disable max-classes-per-file */
+import EmberError from '@ember/error';
+
+export class BinderHubError extends EmberError {
+}
+
+export class MpmPackageEditorError extends BinderHubError {
+}
+/* eslint-enable max-classes-per-file */

--- a/app/guid-node/binderhub/route.ts
+++ b/app/guid-node/binderhub/route.ts
@@ -24,6 +24,10 @@ export default class GuidNodeBinderHubRoute extends Route.extend(ConfirmationMix
                 'server-annotation',
                 { guid: (this.paramsFor('guid-node') as {guid: string}).guid },
             ),
+            customBaseImages: this.store.query(
+                'custom-base-image',
+                { guid: (this.paramsFor('guid-node') as {guid: string}).guid, includeParentImages: true },
+            ),
         });
     }
 

--- a/app/guid-node/binderhub/template.hbs
+++ b/app/guid-node/binderhub/template.hbs
@@ -67,6 +67,7 @@
                     @binderHubConfig={{this.model.binderHubConfig}}
                     @currentBinderHubURL={{this.currentBinderHubURL}}
                     @configFolder={{this.configFolder}}
+                    @initialCustomBaseImages={{this.model.customBaseImages}}
                     @onError={{action this.projectError}}
                     @pagePolluter={{this.pollute}}
                     @pageCleanser={{this.cleanse}}

--- a/app/models/binderhub-config.ts
+++ b/app/models/binderhub-config.ts
@@ -80,6 +80,9 @@ export default class BinderHubConfigModel extends OsfModel {
 
     // tslint:disable-next-line:variable-name
     @attr('array') user_binderhubs!: BinderHubCandidate[];
+
+    // tslint:disable-next-line:variable-name
+    @attr('array') mpm_releases!: string[];
     /* eslint-enable camelcase */
 
     @computed('binderhubs')

--- a/app/models/custom-base-image.ts
+++ b/app/models/custom-base-image.ts
@@ -1,0 +1,28 @@
+import DS from 'ember-data';
+import OsfModel from './osf-model';
+
+const { attr } = DS;
+
+export default class CustomBaseImageModel extends OsfModel {
+    @attr('string') name!: string;
+
+    @attr('string') imageReference!: string;
+
+    @attr('string') descriptionJa!: string;
+
+    @attr('string') descriptionEn!: string;
+
+    @attr('boolean') deprecated!: boolean;
+
+    @attr('string') guid!: string;
+
+    @attr('number') level!: number;
+
+    @attr('string') nodeTitle!: string;
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        'custom-base-image': CustomBaseImageModel;
+    } // eslint-disable-line semi
+}

--- a/app/models/matlab-product-name-list.ts
+++ b/app/models/matlab-product-name-list.ts
@@ -1,0 +1,16 @@
+import DS from 'ember-data';
+import OsfModel from './osf-model';
+
+const { attr } = DS;
+
+export default class MatlabProductNameList extends OsfModel {
+    @attr('string') release!: string;
+
+    @attr('array') names!: string[];
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        'matlab-product-name-list': MatlabProductNameList;
+    } // eslint-disable-line semi
+}

--- a/app/serializers/custom-base-image.ts
+++ b/app/serializers/custom-base-image.ts
@@ -1,0 +1,13 @@
+import OsfSerializer from './osf-serializer';
+
+export default class CustomBaseImageSerializer extends OsfSerializer {
+    keyForAttribute(key: string) {
+        return key;
+    }
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        'custom-base-image': CustomBaseImageSerializer;
+    } // eslint-disable-line semi
+}

--- a/app/serializers/matlab-product-name-list.ts
+++ b/app/serializers/matlab-product-name-list.ts
@@ -1,0 +1,10 @@
+import OsfSerializer from './osf-serializer';
+
+export default class MatlabProductNameListSerializer extends OsfSerializer {
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        'matlab-product-name-list': MatlabProductNameListSerializer;
+    } // eslint-disable-line semi
+}

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -6,6 +6,7 @@ import { getCitation } from './views/citation';
 import { searchCollections } from './views/collection-search';
 import { reportDelete } from './views/comment';
 import { createBibliographicContributor } from './views/contributor';
+import * as customBaseImage from './views/custom-base-image';
 import { createDeveloperApp, updateDeveloperApp } from './views/developer-app';
 import { createDraftRegistration } from './views/draft-registration';
 import {
@@ -263,6 +264,7 @@ export default function(this: Server) {
     this.post('/project/:pid/binderhub/server_annotation', serverAnnotation.create);
     this.del('/project/:pid/binderhub/server_annotation/:aid', serverAnnotation.del);
     this.get('/project/:pid/binderhub/matlab/product_name_list/:release', matlabProductNameList.read);
+    this.get('/project/:pid/binderhub/custom_base_image', customBaseImage.read);
     this.get('/project/:id/metadata/erad/candidates', metadataNodeErad);
     this.get('/project/:id/metadata/project', metadataNodeProject);
 

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -20,6 +20,7 @@ import { guidDetail } from './views/guid';
 import { identifierCreate } from './views/identifier';
 import { summaryMetrics } from './views/institution';
 import { iqbrimsStatus } from './views/iqbrims-status';
+import * as matlabProductNameList from './views/matlab-product-name-list';
 import { metadataNodeErad } from './views/metadata-node-erad';
 import { metadataNodeProject } from './views/metadata-node-project';
 import { createNode } from './views/node';
@@ -261,6 +262,7 @@ export default function(this: Server) {
     this.get('/project/:pid/binderhub/server_annotation', serverAnnotation.read);
     this.post('/project/:pid/binderhub/server_annotation', serverAnnotation.create);
     this.del('/project/:pid/binderhub/server_annotation/:aid', serverAnnotation.del);
+    this.get('/project/:pid/binderhub/matlab/product_name_list/:release', matlabProductNameList.read);
     this.get('/project/:id/metadata/erad/candidates', metadataNodeErad);
     this.get('/project/:id/metadata/project', metadataNodeProject);
 

--- a/mirage/factories/custom-base-image.ts
+++ b/mirage/factories/custom-base-image.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'ember-cli-mirage';
+
+import CustomBaseImageModel from 'ember-osf-web/models/custom-base-image';
+
+export default Factory.extend<CustomBaseImageModel>({
+});
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        customBaseImages: CustomBaseImageModel;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/matlab-product-name-list.ts
+++ b/mirage/factories/matlab-product-name-list.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'ember-cli-mirage';
+
+import MatlabProductNameList from 'ember-osf-web/models/matlab-product-name-list';
+
+export default Factory.extend<MatlabProductNameList>({
+});
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        matlabProductNameLists: MatlabProductNameList;
+    } // eslint-disable-line semi
+}

--- a/mirage/views/custom-base-image.ts
+++ b/mirage/views/custom-base-image.ts
@@ -1,0 +1,52 @@
+import { HandlerContext, Model, Request, Schema } from 'ember-cli-mirage';
+
+import CustomBaseImageModel from 'ember-osf-web/models/custom-base-image';
+
+const makeResourceObject = (model: Model<CustomBaseImageModel>) => ({
+    id: model.id,
+    type: 'custom-base-image',
+    attributes: {
+        name: model.name,
+        imageReference: model.imageReference,
+        descriptionJa: model.descriptionJa,
+        descriptionEn: model.descriptionEn,
+        deprecated: model.deprecated,
+        guid: model.guid,
+        level: model.level,
+        nodeTitle: model.nodeTitle,
+    },
+});
+
+export function create(this: HandlerContext, schema: Schema, req: Request) {
+    const { data } = JSON.parse(req.requestBody);
+    if (!data) {
+        throw new Error('Malformed create request. No "data" property.');
+    }
+    const { attributes } = data;
+    if (!attributes) {
+        throw new Error('Malformed create request. No "attributes" property.');
+    }
+
+    return schema.customBaseImages.create({
+        name: attributes.name,
+        imageReference: attributes.imageReference,
+        descriptionJa: attributes.descriptionJa,
+        descriptionEn: attributes.descriptionEn,
+        deprecated: attributes.deprecated,
+        guid: attributes.guid,
+        level: 0,
+        nodeTitle: `Node ID: ${attributes.guid}`,
+    });
+}
+
+export function read(this: HandlerContext, schema: Schema, req: Request) {
+    return {
+        data: schema.customBaseImages.all().models.filter(
+            image => image.guid === req.params.pid,
+        ).map(makeResourceObject),
+    };
+}
+
+export function del(this: HandlerContext, schema: Schema, req: Request) {
+    return schema.customBaseImages.find(req.params.image_id).destroy();
+}

--- a/mirage/views/matlab-product-name-list.ts
+++ b/mirage/views/matlab-product-name-list.ts
@@ -1,0 +1,31 @@
+import { HandlerContext, Model, Request, Schema } from 'ember-cli-mirage';
+
+import MatlabProductNameList from 'ember-osf-web/models/matlab-product-name-list';
+
+const makeResourceObject = (model: Model<MatlabProductNameList>) => ({
+    id: model.id,
+    type: 'matlab-product-name-list',
+    attributes: {
+        release: model.release,
+        names: model.names,
+    },
+});
+
+export function read(this: HandlerContext, schema: Schema, req: Request) {
+    const model = schema.matlabProductNameLists.all().models.find(({ release }) => release === req.params.release);
+    if (typeof model === 'undefined') {
+        return {
+            data: {
+                id: 0,
+                type: 'matlab-product-name-list',
+                attributes: {
+                    release: 'INVALID',
+                    names: [],
+                },
+            },
+        };
+    }
+    return {
+        data: makeResourceObject(model),
+    };
+}

--- a/tests/acceptance/guid-node/binderhub-test.ts
+++ b/tests/acceptance/guid-node/binderhub-test.ts
@@ -39,6 +39,13 @@ function propertyWithValue(propertyName: string) {
 
 module('Acceptance | guid-node/binderhub', hooks => {
     const guid = 'i9bri';
+    const MATLAB_RELEASES = ['R2024b', 'R2024a', 'R2023b', 'R2023a', 'R2022b', 'R2022a'];
+    const MATLAB_PRODUCT_NAME_LIST = [
+        'arc', 'buchanan', 'common', 'depth', 'eel', 'fledgeling',
+        'guitar', 'hendrix', 'inch', 'jiim', 'king', 'lisp', 'mirror',
+        'next', 'omni', 'purple', 'queue', 'roy', 'stevie', 'telecaster',
+        'testpackage', 'util', 'vaughan', 'xtra', 'you', 'zz', '5GHz',
+    ];
     // HS stands for HostSelector.
     const HS = {
         top: '[data-test-binderhub-host-selector]',
@@ -74,6 +81,12 @@ module('Acceptance | guid-node/binderhub', hooks => {
         closed: '.fa-chevron-right',
         open: '.fa-chevron-down',
         pkgEditor: propertyWithValue('data-test-package-editor'),
+    };
+
+    // MPD stands for Matlab Product Editor
+    const MPE = {
+        top: '[data-test-matlab-product-editor]',
+        product: (v: string) => `input${propertyWithValue('value')(v)}`,
     };
 
     setupOSFApplicationTest(hooks);
@@ -127,6 +140,7 @@ module('Acceptance | guid-node/binderhub', hooks => {
                     },
                 ],
             },
+            mpm_releases: MATLAB_RELEASES,
         });
         server.create('file-provider', { node, name: 'osfstorage' });
         const sandbox = sinon.createSandbox();
@@ -327,6 +341,7 @@ module('Acceptance | guid-node/binderhub', hooks => {
                     },
                 ],
             },
+            mpm_releases: MATLAB_RELEASES,
         });
         server.create('file-provider', { node, name: 'osfstorage' });
         const sandbox = sinon.createSandbox();
@@ -565,6 +580,7 @@ module('Acceptance | guid-node/binderhub', hooks => {
                     },
                 ],
             },
+            mpm_releases: MATLAB_RELEASES,
         });
         server.create('file-provider',
             { node, name: 'osfstorage' });
@@ -719,6 +735,7 @@ module('Acceptance | guid-node/binderhub', hooks => {
                     },
                 ],
             },
+            mpm_releases: MATLAB_RELEASES,
         });
         server.create('file-provider',
             { node, name: 'osfstorage' });
@@ -886,6 +903,7 @@ module('Acceptance | guid-node/binderhub', hooks => {
                     },
                 ],
             },
+            mpm_releases: MATLAB_RELEASES,
         });
         server.create('file-provider',
             { node, name: 'osfstorage' });
@@ -1149,6 +1167,7 @@ module('Acceptance | guid-node/binderhub', hooks => {
                     },
                 ],
             },
+            mpm_releases: MATLAB_RELEASES,
         });
         const osfstorage = server.create('file-provider',
             { node, name: 'osfstorage' });
@@ -1417,7 +1436,17 @@ module('Acceptance | guid-node/binderhub', hooks => {
                     },
                 ],
             },
+            mpm_releases: MATLAB_RELEASES,
         });
+        for (const release of MATLAB_RELEASES) {
+            server.create(
+                'matlab-product-name-list',
+                {
+                    release,
+                    names: MATLAB_PRODUCT_NAME_LIST,
+                },
+            );
+        }
         const osfstorage = server.create('file-provider',
             { node, name: 'osfstorage' });
         const binderFolder = server.create('file', { target: node }, 'asFolder');
@@ -1551,14 +1580,18 @@ module('Acceptance | guid-node/binderhub', hooks => {
             ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser?include_stopped_servers=1', null),
             'BinderHub calls JupyterHub REST API',
         );
-        assert.dom('[data-test-package-editor="mpm"] button[data-test-package-edit-item]').doesNotExist();
+        assert.dom(`${PE.top} ${PE.pkgEditor('mpm')} button[data-test-current-release]`).exists();
 
-        await click('[data-test-package-editor="mpm"] [data-test-mpm-product-add]');
+        await click(`${PE.top} ${PE.pkgEditor('mpm')} button[data-test-current-release]`);
 
-        assert.dom('[data-test-package-editor="mpm"] input[name="package_name"]').exists();
-        assert.dom('[data-test-package-editor="mpm"] button[data-test-named-item-confirm]').exists();
-        await fillIn('[data-test-package-editor="mpm"] input[name="package_name"]', 'testpackage');
-        await click('[data-test-package-editor="mpm"] button[data-test-named-item-confirm]');
+        assert.dom(`${PE.top} ${PE.pkgEditor('mpm')} button[data-test-pick-release="R2023b"]`).exists();
+        await click(`${PE.top} ${PE.pkgEditor('mpm')} button[data-test-pick-release="R2023b"]`);
+        assert.dom(`${PE.top} ${PE.pkgEditor('mpm')} button[data-test-mpm-product-add]`).exists();
+        await click(`${PE.top} ${PE.pkgEditor('mpm')} button[data-test-mpm-product-add]`);
+        assert.dom(`${MPE.top}`).exists();
+        await click(`${MPE.top} ${MPE.product('testpackage')}`);
+        await click(`${MPE.top} .close`);
+        assert.dom(`${MPE.top}`).doesNotExist();
 
         assert.equal(
             getContentsStub.callCount,
@@ -1629,6 +1662,10 @@ module('Acceptance | guid-node/binderhub', hooks => {
         assert.dom('[data-test-package-editor="mpm"] button[data-test-mpm-product-edit-item="0"]').exists();
         assert.dom('[data-test-package-editor="mpm"] button[data-test-mpm-product-edit-item="1"]').doesNotExist();
 
+        await click(`${PE.top} ${PE.pkgEditor('mpm')} button[data-test-current-release]`);
+        await click(`${PE.top} ${PE.pkgEditor('mpm')} button[data-test-clear-release]`);
+        assert.dom(`${PE.top} ${PE.pkgEditor('mpm')} button[data-test-mpm-product-add]`).doesNotExist();
+
         sandbox.restore();
     });
 
@@ -1694,6 +1731,7 @@ module('Acceptance | guid-node/binderhub', hooks => {
                     },
                 ],
             },
+            mpm_releases: MATLAB_RELEASES,
         });
         server.create('file-provider',
             { node, name: 'osfstorage' });

--- a/tests/acceptance/guid-node/binderhub-test.ts
+++ b/tests/acceptance/guid-node/binderhub-test.ts
@@ -77,6 +77,15 @@ module('Acceptance | guid-node/binderhub', hooks => {
         selection: propertyWithValue('data-test-image-selection'),
         change: propertyWithValue('data-test-image-change'),
         selected: propertyWithValue('data-test-image-selected'),
+        custom: {
+            top: '[data-test-custom-base-image]',
+            moreMenu: '[data-test-more-menu]',
+            delete: '[data-test-delete-custom-base-image]',
+            edit: '[data-test-edit-custom-base-image]',
+        },
+        deleteConfirmation: '[data-test-custom-base-image-delete-confirmation]',
+        doDelete: '[data-test-do-delete-custom-base-image]',
+        cancelDelete: '[data-test-cancel-delete]',
         separator: '[data-test-deprecated-image-separator]',
         closed: '.fa-chevron-right',
         open: '.fa-chevron-down',
@@ -141,6 +150,39 @@ module('Acceptance | guid-node/binderhub', hooks => {
                 ],
             },
             mpm_releases: MATLAB_RELEASES,
+        });
+        server.create('custom-base-image', {
+            id: '1',
+            name: 'Ubuntu Base',
+            imageReference: 'docker.io/library/ubuntu:latest',
+            descriptionJa: '標準的な Ubuntu イメージ',
+            descriptionEn: 'Standard Ubuntu image',
+            deprecated: false,
+            guid,
+            level: 0,
+            nodeTitle: 'A great Project',
+        });
+        server.create('custom-base-image', {
+            id: '2',
+            name: 'Python Base',
+            imageReference: 'docker.io/library/python:3.9',
+            descriptionJa: 'Python 3.9 環境を含むイメージ',
+            descriptionEn: 'Image with Python 3.9 environment',
+            deprecated: false,
+            guid,
+            level: 0,
+            nodeTitle: 'A great Project',
+        });
+        server.create('custom-base-image', {
+            id: '3',
+            name: 'Steel Bank Common Lisp',
+            imageReference: 'docker.io/library/sbcl',
+            descriptionJa: 'Steel Bank Common Lisp試験用',
+            descriptionEn: 'Try out SBCL',
+            deprecated: false,
+            guid: 'dummy',
+            level: 0,
+            nodeTitle: 'A dummy Project',
         });
         server.create('file-provider', { node, name: 'osfstorage' });
         const sandbox = sinon.createSandbox();
@@ -207,6 +249,7 @@ module('Acceptance | guid-node/binderhub', hooks => {
         assert.dom(`${PE.top} ${PE.selection()}`).doesNotExist();
         assert.dom(`${PE.top} ${PE.change('jupyter/test-image')}`).exists();
         assert.dom(`${PE.top} ${PE.selected('jupyter/test-image')}`).exists();
+        assert.dom(`${PE.top} ${PE.custom.top}`).doesNotExist();
         assert.dom(`${PE.top} ${PE.pkgEditor('apt')}`).exists();
         assert.dom(`${PE.top} ${PE.pkgEditor('conda')}`).exists();
         assert.dom(`${PE.top} ${PE.pkgEditor('pip')}`).doesNotExist();
@@ -232,6 +275,16 @@ module('Acceptance | guid-node/binderhub', hooks => {
             ajaxStub.calledOnceWithExactly('http://localhost:30123/', 'users/testuser?include_stopped_servers=1', null),
             'BinderHub calls JupyterHub REST API',
         );
+
+        await click(`${PE.top} ${PE.change('jupyter/test-image')}`);
+        assert.dom(`${PE.top} ${PE.custom.top}`).exists({ count: 2 });
+        assert.dom(`${PE.top} ${PE.custom.top} ${PE.custom.moreMenu}`).exists({ count: 2 });
+        await click(`${PE.top} ${PE.custom.top} ${PE.custom.moreMenu}`);
+        await click(`${PE.top} ${PE.custom.top} ${PE.custom.delete}`);
+        assert.dom(`${PE.deleteConfirmation}`).exists();
+        await click(`${PE.deleteConfirmation} ${PE.cancelDelete}`);
+        assert.dom(`${PE.deleteConfirmation}`).doesNotExist();
+        assert.dom(`${PE.top} ${PE.custom.top}`).exists({ count: 2 });
 
         sandbox.restore();
     });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1811,6 +1811,8 @@ binderhub:
         postinstallscript: 'Auto-Execution Script'
         select_environment: 'Select'
         change_environment: 'Change'
+        delete_button_label: 'Delete'
+        more_menu: '...'
         deprecated_images_header: 'Deprecated images'
         add_package: 'Add'
         view_dirty_fragile_files: 'View: '
@@ -1846,6 +1848,35 @@ binderhub:
         placeholders:
             package_name: 'Name'
             package_version: 'Version'
+        custom_base_image:
+            entry:
+                fatal_title: 'Failed to update the custom base image.'
+                fatal_message: 'The custom base image you were editing has already been deleted.'
+            dialogue:
+                title: 'Custom Base Image registration'
+                registration_succeeded: '`{name} has been added.'
+                create_new: 'Create New'
+                inherit: 'Inherit from ancestor projects'
+                no_relevants: 'This project has no ancestor or linked projects.'
+                obtain_button: 'Obtain'
+                information: 'The whitespace characters at the beginning and end of the image URL are ingored. And, it must be unique within the project.'
+                already_in_use: 'Image URL: {imageReference} is already in use.'
+                mandatory_field: 'Title and Image URL must not be empty.'
+                repo2docker: 'Image URL must not start with "#repo2docker"'
+                name_label: 'Title'
+                reference_label: 'Image URL'
+                description_ja_label: 'Description in Japanese'
+                description_en_label: 'Description in English'
+                register_button_label: 'Register'
+            delete_confirmation:
+                title: 'Base Image delete confirmation'
+                content: 'The deletion of base image cannot be retrieved. Are you sure you wan to proceed?'
+            editor:
+                title: 'Custom Base Image edit'
+                update_button_label: 'UPDATE'
+                mandatory_field: 'Title must not be empty.'
+                update_succeeded: 'Update succeeded.'
+                image_reference_hint: 'Image URL cannot be edited.'
     build:
         launch: 'Launch'
         status: 'Build status'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1830,13 +1830,22 @@ binderhub:
         destruct_dockerfile_confirmation_dialogue_title: 'Dockerfile reset confirmation'
         destruct_dockerfile_confirmation_dialogue_body: 'If you change the base image, Dockerfile you are currently editing will be reset. Please note that the lost content cannot be retrieved. Are you sure you want to proceed?'
         release: 'Release'
-        products: 'Add-ons'
+        clear_release: '(clear)'
+        edit_product_button_label: 'Edit Add-ons'
+        edit_product_dialogue:
+          title: 'Edit Add-ons'
+          search_placeholder: 'serach addons'
+          manual_edit:
+            tab_title: 'Specify manually'
+            add_button: 'Add'
+            message_on_add: '{product_name} has been added.'
+            message_on_conflict: '{product_name} has already been added.'
+            message_on_invalid: 'Invalid addon name. Addon name must not include whitespace characters'
         info_urls:
             mpm: 'https://rcosdp.github.io/CS-repo2docker/MATLAB.html'
         placeholders:
             package_name: 'Name'
             package_version: 'Version'
-            release: 'R2023b'
     build:
         launch: 'Launch'
         status: 'Build status'

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -1811,7 +1811,9 @@ binderhub:
         postinstallscript: '自動実行スクリプト'
         select_environment: '選択'
         change_environment: '変更'
+        more_menu: '...'
         deprecated_images_header: '過去のイメージ'
+        delete_button_label: '削除'
         add_package: '追加'
         view_dirty_fragile_files: '参照: '
         reset_dirty_fragile_files: 'リセット: '
@@ -1846,6 +1848,35 @@ binderhub:
         placeholders:
             package_name: '名前'
             package_version: 'バージョン'
+        custom_base_image:
+            entry:
+                fatal_title: 'カスタム基本イメージの更新に失敗しました'
+                fatal_message: '編集対象のカスタム基本イメージは既に削除されています。'
+            dialogue:
+                title: 'カスタム基本イメージの登録'
+                registration_succeeded: '「{name}」を追加しました'
+                create_new: '新規作成'
+                inherit: '親プロジェクトから取得'
+                no_relevants: '親プロジェクトやリンクされたプロジェクトがありません。'
+                obtain_button: '取得'
+                information: 'イメージURLの先頭および末尾の空白文字は無視されます。また、プロジェクト内でユニークである必要があります。'
+                already_in_use: 'イメージURL: {imageReference} を利用する基本イメージは既に存在します。'
+                mandatory_field: '基本イメージ名とイメージURLとして空文字列は指定できません。'
+                repo2docker: '"#repo2docker"から始まるイメージURLは禁止されています。'
+                name_label: '基本イメージ名'
+                reference_label: 'イメージURL'
+                description_ja_label: 'イメージの概要(日本語)'
+                description_en_label: 'イメージの概要(英語)'
+                register_button_label: '登録'
+            delete_confirmation:
+                title: '基本イメージの削除確認'
+                content: '基本イメージの削除は取り消せません。削除しますか？'
+            editor:
+                title: 'カスタム基本イメージの編集'
+                update_button_label: '更新'
+                mandatory_field: '基本イメージ名として空文字列は指定できません。'
+                update_succeeded: '更新しました'
+                image_reference_hint: 'イメージURLは編集できません'
     build:
         launch: '起動'
         status: 'ビルド状況'

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -1830,13 +1830,22 @@ binderhub:
         destruct_dockerfile_confirmation_dialogue_title: 'Dockerfileの削除確認'
         destruct_dockerfile_confirmation_dialogue_body: '基本イメージを変更すると、あなたが編集中のDockerfileの内容が破棄されます。失われた内容を復元することはできません。続行しますか？'
         release: 'リリース'
-        products: 'アドオン'
+        clear_release: '(クリア)'
+        edit_product_button_label: 'アドオンを編集'
+        edit_product_dialogue:
+          title: 'アドオン編集'
+          search_placeholder: 'アドオンを検索'
+          manual_edit:
+            tab_title: 'アドオン名を直接指定'
+            add_button: '追加'
+            message_on_add: '{product_name}を追加しました。'
+            message_on_conflict: '{product_name}は既に追加されています。'
+            message_on_invalid: 'アドオン名は空白文字を含むことはできません。'
         info_urls:
             mpm: 'https://rcosdp.github.io/CS-repo2docker/MATLAB.html'
         placeholders:
             package_name: '名前'
             package_version: 'バージョン'
-            release: 'R2023b'
     build:
         launch: '起動'
         status: 'ビルド状況'


### PR DESCRIPTION
対応するosf.io側の実装は [#577](https://github.com/RCOSDP/RDM-osf.io/pull/577)です。同時にマージしてください。

- Ticket: [44130,  44129, 47160]
- Feature flag: n/a

## Purpose

MATLABのパッケージ選択UI(チケット44129)とカスタムイメージ登録機能(チケット47160)を実装した。

## Summary of Changes

+ MATLABアドオンを一覧から選ぶためのUI
+ プロジェクトごとに、基本イメージをプロジェクトメンバーが登録・利用できるカスタム基本イメージ機能とそのUI
  - カスタム基本イメージの編集と削除の機能とそのUI
  - プロジェクトの親プロジェクトおよびリンクしたプロジェクトのうち、読み出し権限を持つプロジェクトからカスタム基本イメージを取得する機能とそのUI

## Side Effects

MATLABアドオンのリリース名および各リリースに含まれるアドオンの一覧はosf.io側から配信され、また、カスタム基本イメージはosf.io側に保存される。このため、[対応するosf.io側の実装#577](https://github.com/RCOSDP/RDM-osf.io/pull/577)を同時に利用する必要がある。
