### PR TITLE
[GRDM-50321] Project Metadata関連リソースの権限調整

### DIFF
--- a/app/guid-node/metadata/template.hbs
+++ b/app/guid-node/metadata/template.hbs
@@ -32,18 +32,18 @@
                             <nl.empty>
                                 <p>
                                     {{t 'node.metadata.no_reports'}}
-                                    {{#if (and this.node.currentUserIsContributor (not this.node.userHasAdminPermission))}}
-                                        {{t 'node.metadata.only_admins_can_initiate'}}
+                                    {{#if (and this.node.currentUserIsContributor (not this.node.userHasWritePermission))}}
+                                        {{t 'node.metadata.only_contributors_with_write_permission_can_initiate'}}
                                     {{/if}}
                                 </p>
-                                {{#if this.node.userHasAdminPermission}}
+                                {{#if this.node.userHasWritePermission}}
                                     <p>{{t 'node.metadata.start_new'}}</p>
                                 {{/if}}
                             </nl.empty>
                         </NodeList>
                     </div>
                 </tab.pane>
-                {{#if this.node.userHasAdminPermission}}
+                {{#if this.node.userHasWritePermission}}
                     <tab.pane
                       data-analytics-scope='Drafts tab'
                       @id='drafts'
@@ -76,7 +76,7 @@
                 {{/if}}
             </BsTab>
         </div>
-        {{#if this.node.userHasAdminPermission}}
+        {{#if this.node.userHasWritePermission}}
             <div class='col-xs-3 col-sm-4'>
                 <OsfButton
                     data-test-new-metadata-button

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -645,7 +645,7 @@ node:
             note: '*Metadata forms will be constantly added as the number of corresponding projects and institutions grows in the future.'
             create: 'Create Metadata'
         page_title: '{nodeTitle} Metadata'
-        only_admins_can_initiate: 'Only project administrators can initiate metadata.'
+        only_contributors_with_write_permission_can_initiate: 'Only contributors with write permission can initiate metadata.'
         no_reports: 'There are no metadata of this project.'
         no_drafts: 'There are no draft metadata of this project.'
         start_new: 'Start to edit a new metadata by clicking the “Create new metadata” button. Once created, metadata cannot be edited or deleted.'

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -645,7 +645,7 @@ node:
             note: ＊今後、対応する事業や機関の増加に合わせて、メタデータの様式は随時追加されていきます。
             create: メタデータを作成
         page_title: '{nodeTitle} メタデータ'
-        only_admins_can_initiate: プロジェクト管理者のみがメタデータ作成を開始できます。
+        only_contributors_with_write_permission_can_initiate: 'プロジェクトの書き込み権限を持つメンバーのみがメタデータ編集を実施できます。'
         no_reports: このプロジェクトのメタデータはありません。
         no_drafts: このプロジェクトに関する下書きはありません。
         start_new: '「新規メタデータを作成」ボタンをクリックして、新規メタデータ作成を開始します。一度登録したメタデータを、編集または削除することはできません。'


### PR DESCRIPTION
- Ticket: GRDM-50321
- Feature flag: n/a

osf.io側の修正と合わせてMergeしてください。 https://github.com/RCOSDP/RDM-osf.io/pull/579

## Purpose

Project Metadata関連リソースの権限調整

## Summary of Changes

- Project Metadataを非管理者でも書き込み権限があれば操作できるよう、メタデータ編集画面を修正

## Side Effects

None

## QA Notes

None
