### PR TITLE
[GRDM-41018] プロジェクトメタデータにてRegistration化をしないようにする

### DIFF
--- a/app/guid-node/metadata/controller.ts
+++ b/app/guid-node/metadata/controller.ts
@@ -21,9 +21,6 @@ export default class GuidNodeMetadata extends Controller {
     @service analytics!: Analytics;
     @service store!: DS.Store;
 
-    queryParams = ['tab'];
-    tab?: string;
-
     draftsQueryParams = { embed: ['initiator', 'registration_schema', 'branched_from'] };
     defaultSchema!: RegistrationSchema;
     selectedSchema!: RegistrationSchema;
@@ -64,20 +61,9 @@ export default class GuidNodeMetadata extends Controller {
 
     @alias('model.taskInstance.value') node!: Node | null;
 
-    @computed('tab')
-    get activeTab() {
-        return this.tab ? this.tab : 'reports';
-    }
-
     @computed('node.{id,root.id,root.userHasAdminPermission}')
     get isComponentRootAdmin() {
         return this.node && this.node.id !== this.node.root.get('id') && this.node.root.get('userHasAdminPermission');
-    }
-
-    @action
-    changeTab(activeId: string) {
-        this.set('tab', activeId === 'reports' ? undefined : activeId);
-        this.analytics.click('tab', `Reports tab - Change tab to: ${activeId}`);
     }
 
     @action

--- a/app/guid-node/metadata/styles.scss
+++ b/app/guid-node/metadata/styles.scss
@@ -5,6 +5,17 @@
 
 .ReportsPane {
     min-height: 150px;
+
+    :global(li:not(.list-group-item)) {
+        list-style-type: none;
+    }
+}
+
+.RegistrationsHeader {
+    color: $color-text-gray-dark;
+    font-size: 13px;
+    font-weight: bold;
+    margin-top: 2em;
 }
 
 h4:global(.NewReportModal__header) {

--- a/app/guid-node/metadata/template.hbs
+++ b/app/guid-node/metadata/template.hbs
@@ -8,73 +8,50 @@
 >
     <div class='row'>
         <div class='col-xs-9 col-sm-8'>
-            <BsTab
-              data-analytics-scope='Reports Tab'
-              @activeId={{this.activeTab}}
-              @onChange={{action this.changeTab}}
-              as |tab|
-            >
-                <tab.pane
-                  @id='reports'
-                  @title={{t 'node.metadata.reports'}}
+            <div class='row' local-class='ReportsPane' data-test-draft-reports-pane>
+                <PaginatedList::HasMany
+                    data-analytics-scope='Project Reports'
+                    @modelTaskInstance={{this.model.taskInstance}}
+                    @relationshipName='draftRegistrations'
+                    @bindReload={{action (mut this.reloadDrafts)}}
+                    @query={{this.draftsQueryParams}}
+                    as |list|
                 >
-                    <div class='row' local-class='ReportsPane' data-test-reports-pane>
-                        <NodeList
-                            @modelTaskInstance={{this.model.taskInstance}}
-                            @relationshipName='registrations'
-                            @showTags={{true}}
-                            @disableNodeLink={{true}}
-                            @showExportCsvLink={{true}}
+                    <list.item as |draftRegistration|>
+                        <DraftRegistrationCard
+                            @draftRegistration={{draftRegistration}}
                             @metadataSchema={{this.metadataSchema}}
-                            @showStatus={{false}}
-                            as |nl|
-                        >
-                            <nl.empty>
-                                <p>
-                                    {{t 'node.metadata.no_reports'}}
-                                    {{#if (and this.node.currentUserIsContributor (not this.node.userHasWritePermission))}}
-                                        {{t 'node.metadata.only_contributors_with_write_permission_can_initiate'}}
-                                    {{/if}}
-                                </p>
-                                {{#if this.node.userHasWritePermission}}
-                                    <p>{{t 'node.metadata.start_new'}}</p>
-                                {{/if}}
-                            </nl.empty>
-                        </NodeList>
-                    </div>
-                </tab.pane>
-                {{#if this.node.userHasWritePermission}}
-                    <tab.pane
-                      data-analytics-scope='Drafts tab'
-                      @id='drafts'
-                      @title={{t 'node.metadata.draft_reports'}}
-                    >
-                        <div class='row' local-class='ReportsPane' data-test-draft-reports-pane>
-                            <PaginatedList::HasMany
-                                data-analytics-scope='Project Reports'
-                                @modelTaskInstance={{this.model.taskInstance}}
-                                @relationshipName='draftRegistrations'
-                                @bindReload={{action (mut this.reloadDrafts)}}
-                                @query={{this.draftsQueryParams}}
-                                as |list|
-                            >
-                                <list.item as |draftRegistration|>
-                                    <DraftRegistrationCard
-                                        @draftRegistration={{draftRegistration}}
-                                        @metadataSchema={{this.metadataSchema}}
-                                        @onDelete={{action list.doReload 1}}
-                                    />
-                                </list.item>
+                            @onDelete={{action list.doReload 1}}
+                        />
+                    </list.item>
 
-                                <list.empty>
-                                    <p>{{t 'node.metadata.no_reports'}}</p>
-                                    <p>{{t 'node.metadata.start_new'}}</p>
-                                </list.empty>
-                            </PaginatedList::HasMany>
-                        </div>
-                    </tab.pane>
-                {{/if}}
-            </BsTab>
+                    <list.empty>
+                        <p>{{t 'node.metadata.no_reports'}}</p>
+                        {{#if (and this.node.currentUserIsContributor (not this.node.userHasWritePermission))}}
+                            {{t 'node.metadata.only_contributors_with_write_permission_can_initiate'}}
+                        {{/if}}
+                        {{#if this.node.userHasWritePermission}}
+                            <p>{{t 'node.metadata.start_new'}}</p>
+                        {{/if}}
+                    </list.empty>
+                </PaginatedList::HasMany>
+                <NodeList
+                    @modelTaskInstance={{this.model.taskInstance}}
+                    @relationshipName='registrations'
+                    @showTags={{true}}
+                    @disableNodeLink={{true}}
+                    @showExportCsvLink={{true}}
+                    @metadataSchema={{this.metadataSchema}}
+                    @showStatus={{false}}
+                    as |nl|
+                >
+                    <nl.header>
+                        <p local-class='RegistrationsHeader'>
+                            {{t 'node.metadata.registrations'}}
+                        </p>
+                    </nl.header>
+                </NodeList>
+            </div>
         </div>
         {{#if this.node.userHasWritePermission}}
             <div class='col-xs-3 col-sm-4'>

--- a/app/utils/metadata-title-field-priority.ts
+++ b/app/utils/metadata-title-field-priority.ts
@@ -1,0 +1,12 @@
+/**
+ * Priority order for title fields in registration metadata responses.
+ * The first matching field with a value will be used as the display title.
+ */
+export const METADATA_TITLE_FIELD_PRIORITY = [
+    'project-name-ja',
+    'project-name-en',
+    'title-of-dataset',
+    'title-of-dataset-en',
+] as const;
+
+export type MetadataTitleFieldType = typeof METADATA_TITLE_FIELD_PRIORITY[number];

--- a/lib/osf-components/addon/components/draft-registration-card/component.ts
+++ b/lib/osf-components/addon/components/draft-registration-card/component.ts
@@ -8,6 +8,7 @@ import { layout } from 'ember-osf-web/decorators/component';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
 import MetadataNodeSchemaModel from 'ember-osf-web/models/metadata-node-schema';
 import Analytics from 'ember-osf-web/services/analytics';
+import { METADATA_TITLE_FIELD_PRIORITY } from 'ember-osf-web/utils/metadata-title-field-priority';
 import pathJoin from 'ember-osf-web/utils/path-join';
 
 import styles from './styles';
@@ -47,6 +48,27 @@ export default class DraftRegistrationCard extends Component {
     get registrationSchemaId(): string | null {
         const draftRegistration = this.get('draftRegistration');
         return draftRegistration.registrationSchema.get('id');
+    }
+
+    @computed('draftRegistration.{registrationResponses,title}')
+    get displayTitle(): string {
+        const draftRegistration = this.get('draftRegistration');
+        if (!draftRegistration) {
+            return '';
+        }
+        const responses = draftRegistration.registrationResponses;
+        if (responses) {
+            for (const field of METADATA_TITLE_FIELD_PRIORITY) {
+                // __responseKey_ プレフィックス付きと無し両方を試す
+                const responseKeyField = `__responseKey_${field}`;
+                const value = responses[responseKeyField] || responses[field];
+                if (typeof value === 'string' && value.trim()) {
+                    return value.trim();
+                }
+            }
+        }
+        // フォールバック: title属性を使用
+        return draftRegistration.title || '';
     }
 
     @action

--- a/lib/osf-components/addon/components/draft-registration-card/styles.scss
+++ b/lib/osf-components/addon/components/draft-registration-card/styles.scss
@@ -33,6 +33,10 @@
     }
 }
 
+.DraftRegistrationCard__export button {
+    float: right;
+}
+
 :global(.delete_draft_registration) {
     :global(.modal-header) {
         h4 {

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -10,7 +10,7 @@
                 @route='registries.drafts.draft'
                 @models={{array this.draftRegistration.id}}
             >
-                {{this.draftRegistration.title}}
+                {{this.displayTitle}}
             </OsfLink>
         {{else}}
             <ContentPlaceholders as |placeholder|>

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -89,7 +89,7 @@
                         </modal.footer>
                     </BsModal>
                 </div>
-                <div class='col-md-2'>
+                <div class='col-md-3' local-class='DraftRegistrationCard__export'>
                     <RegistrationReportExportButton
                         @metadataType='draft_registration'
                         @metadataId={{this.draftRegistration.id}}

--- a/lib/osf-components/addon/components/node-card/component.ts
+++ b/lib/osf-components/addon/components/node-card/component.ts
@@ -11,6 +11,7 @@ import Registration from 'ember-osf-web/models/registration';
 import { Question } from 'ember-osf-web/models/registration-schema';
 import Analytics from 'ember-osf-web/services/analytics';
 import defaultTo from 'ember-osf-web/utils/default-to';
+import { METADATA_TITLE_FIELD_PRIORITY } from 'ember-osf-web/utils/metadata-title-field-priority';
 import pathJoin from 'ember-osf-web/utils/path-join';
 
 import styles from './styles';
@@ -96,5 +97,30 @@ export default class NodeCard extends Component {
     @computed('readOnly', 'node', 'node.{nodeType,userHasWritePermission}')
     get showDropdown() {
         return !this.readOnly && this.node && this.node.nodeType === NodeType.Fork && this.node.userHasWritePermission;
+    }
+
+    @computed('node.{registrationResponses,title}')
+    get displayTitle(): string {
+        const node = this.get('node');
+        if (!node) {
+            return '';
+        }
+        // Registrationの場合、registrationResponsesをチェック
+        if (node.isRegistration) {
+            const registration = node as Registration;
+            const responses = registration.registrationResponses;
+            if (responses) {
+                for (const field of METADATA_TITLE_FIELD_PRIORITY) {
+                    // __responseKey_ プレフィックス付きと無し両方を試す
+                    const responseKeyField = `__responseKey_${field}`;
+                    const value = responses[responseKeyField] || responses[field];
+                    if (typeof value === 'string' && value.trim()) {
+                        return value.trim();
+                    }
+                }
+            }
+        }
+        // フォールバック: title属性を使用
+        return node.title || '';
     }
 }

--- a/lib/osf-components/addon/components/node-card/styles.scss
+++ b/lib/osf-components/addon/components/node-card/styles.scss
@@ -78,3 +78,7 @@
         font-weight: 600;
     }
 }
+
+.NodeCard__exportCsvLink {
+    text-align: right;
+}

--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -31,14 +31,14 @@
                 {{/if}}
                 {{node-card/node-icon category=@node.category}}
                 {{#if this.disableNodeLink}}
-                    {{@node.title}}
+                    {{this.displayTitle}}
                 {{else if this.schemaUrl}}
                     <OsfLink
                         data-analytics-name='Title'
                         data-test-node-title='{{@node.id}}'
                         @href={{this.schemaUrl}}
                     >
-                        {{@node.title}}
+                        {{this.displayTitle}}
                     </OsfLink>
                 {{else}}
                     <OsfLink
@@ -47,7 +47,7 @@
                       @route='resolve-guid'
                       @models={{array @node.id}}
                     >
-                        {{@node.title}}
+                        {{this.displayTitle}}
                     </OsfLink>
                 {{/if}}
             {{else}}

--- a/lib/osf-components/addon/components/node-list/template.hbs
+++ b/lib/osf-components/addon/components/node-list/template.hbs
@@ -17,4 +17,5 @@
     </list.item>
 
     {{yield (hash empty=list.empty)}}
+    {{yield (hash header=list.header)}}
 </PaginatedList::HasMany>

--- a/lib/osf-components/addon/components/registration-report-export-button/component.ts
+++ b/lib/osf-components/addon/components/registration-report-export-button/component.ts
@@ -36,9 +36,13 @@ export default class RegistrationReportExportButton extends Component {
 
     @service toast!: Toast;
 
+    buttonClass?: string;
+
     exportCsvUrl?: string;
 
     metadataSchema?: MetadataNodeSchemaModel;
+
+    metadataSchemaLoading: boolean = false;
 
     registrationSchemaId?: string | null = null;
 
@@ -80,9 +84,14 @@ export default class RegistrationReportExportButton extends Component {
         return this.metadataFormats.length === 0;
     }
 
-    @computed('metadataFormats')
+    @computed('metadataDestinations')
     get hasNoDestinations(): boolean {
         return this.metadataDestinations.length === 0;
+    }
+
+    @computed('metadataSchemaLoading', 'hasNoFormats', 'hasNoDestinations')
+    get isDisabled(): boolean {
+        return this.metadataSchemaLoading || (this.hasNoFormats && this.hasNoDestinations);
     }
 
     @action

--- a/lib/osf-components/addon/components/registration-report-export-button/template.hbs
+++ b/lib/osf-components/addon/components/registration-report-export-button/template.hbs
@@ -57,8 +57,9 @@
 <OsfButton
     data-test-registration-card-export
     data-analytics-name='Export'
+    class={{this.buttonClass}}
     @type='success'
-    @disabled={{and this.hasNoFormats this.hasNoDestinations}}
+    @disabled={{this.isDisabled}}
     @onClick={{action this.export}}
 >
     {{t 'metadata.registration-card.export'}}

--- a/lib/registries/addon/drafts/draft/-components/register/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/register/component.ts
@@ -1,17 +1,22 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
-import { action } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { run } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import DS from 'ember-data';
 
+import config from 'ember-get-config';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
+import MetadataNodeSchemaModel from 'ember-osf-web/models/metadata-node-schema';
 import NodeModel from 'ember-osf-web/models/node';
 import Registration from 'ember-osf-web/models/registration';
+import pathJoin from 'ember-osf-web/utils/path-join';
 import DraftRegistrationManager from 'registries/drafts/draft/draft-registration-manager';
+
+const { OSF: { url: baseURL } } = config;
 
 @tagName('')
 export default class Register extends Component.extend({
@@ -39,6 +44,13 @@ export default class Register extends Component.extend({
     // Required
     draftManager!: DraftRegistrationManager;
 
+    // Optional arguments
+    metadataSchema?: MetadataNodeSchemaModel;
+
+    metadataSchemaLoading = false;
+
+    showMobileView = false;
+
     // Private
     registration!: Registration;
     onSubmitRedirect?: (nodeId: string) => void;
@@ -51,6 +63,32 @@ export default class Register extends Component.extend({
 
     didReceiveAttrs() {
         assert('@draftManager is required!', Boolean(this.draftManager));
+    }
+
+    @computed('draftRegistration')
+    get registrationSchemaId(): string | null {
+        const draftRegistration = this.get('draftRegistration');
+        return draftRegistration.registrationSchema.get('id');
+    }
+
+    @computed('draftRegistration')
+    get exportCsvUrl() {
+        const draftRegistration = this.get('draftRegistration');
+        const node = draftRegistration.get('branchedFrom');
+        return pathJoin(
+            baseURL,
+            node.get('id'),
+            `metadata/draft_registrations/${draftRegistration.get('id')}/csv`,
+        );
+    }
+
+    @computed('showMobileView')
+    get registerButtonClass() {
+        let classes = 'registerButton exportButton';
+        if (this.showMobileView) {
+            classes += ' mobileReviewButtonItem';
+        }
+        return classes;
     }
 
     @action

--- a/lib/registries/addon/drafts/draft/-components/register/styles.scss
+++ b/lib/registries/addon/drafts/draft/-components/register/styles.scss
@@ -21,3 +21,7 @@
     border-radius: 0;
     padding: 10px;
 }
+
+.exportButton {
+    width: 100%;
+}

--- a/lib/registries/addon/drafts/draft/-components/register/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/register/template.hbs
@@ -1,13 +1,23 @@
-<RegistrationReportExportButton
-    data-test-draft-export
-    @buttonClass={{local-class this.registerButtonClass}}
-    @metadataType='draft_registration'
-    @metadataId={{this.draftRegistration.id}}
-    @metadataSchema={{this.metadataSchema}}
-    @metadataSchemaLoading={{this.metadataSchemaLoading}}
-    @registrationSchemaId={{this.registrationSchemaId}}
-    @exportCsvUrl={{this.exportCsvUrl}}
-/>
+<div data-test-draft-export>
+    <RegistrationReportExportButton
+        @buttonClass={{local-class this.registerButtonClass}}
+        @metadataType='draft_registration'
+        @metadataId={{this.draftRegistration.id}}
+        @metadataSchema={{this.metadataSchema}}
+        @metadataSchemaLoading={{this.metadataSchemaLoading}}
+        @registrationSchemaId={{this.registrationSchemaId}}
+        @exportCsvUrl={{this.exportCsvUrl}}
+    />
+    <OsfLink
+        data-analytics-name='Edit Complete'
+        class='btn btn-default'
+        @route='guid-node.metadata'
+        @models={{array this.node.id}}
+        style='margin-top: 10px; width: 100%;'
+    >
+        {{t 'registries.drafts.draft.edit_complete'}}
+    </OsfLink>
+</div>
 
 {{#if this.node}}
     <Registries::PartialRegistrationModal::Manager

--- a/lib/registries/addon/drafts/draft/-components/register/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/register/template.hbs
@@ -8,15 +8,14 @@
         @registrationSchemaId={{this.registrationSchemaId}}
         @exportCsvUrl={{this.exportCsvUrl}}
     />
-    <OsfLink
+    <a
         data-analytics-name='Edit Complete'
         class='btn btn-default'
-        @route='guid-node.metadata'
-        @models={{array this.node.id}}
+        href='/{{this.node.id}}/metadata?tab=reports'
         style='margin-top: 10px; width: 100%;'
     >
         {{t 'registries.drafts.draft.edit_complete'}}
-    </OsfLink>
+    </a>
 </div>
 
 {{#if this.node}}

--- a/lib/registries/addon/drafts/draft/-components/register/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/register/template.hbs
@@ -1,22 +1,13 @@
-<OsfButton
-    data-test-goto-register
-    data-analytics-name='Go to register'
-    local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
-    @type='success'
-    @onClick={{perform this.onClickRegister}}
-    @disabled={{not this.draftManager.registrationResponsesIsValid}}
->
-    {{#if this.onClickRegister.isRunning}}
-        <LoadingIndicator @inline={{true}} />
-    {{else}}
-        {{t 'registries.drafts.draft.register'}}
-    {{/if}}
-</OsfButton>
-{{#if (and this.isInvalid (not @showMobileView))}}
-    <div data-test-invalid-responses-text class='text-danger'>
-        {{t 'registries.drafts.draft.review.invalid_warning'}}
-    </div>
-{{/if}}
+<RegistrationReportExportButton
+    data-test-draft-export
+    @buttonClass={{local-class this.registerButtonClass}}
+    @metadataType='draft_registration'
+    @metadataId={{this.draftRegistration.id}}
+    @metadataSchema={{this.metadataSchema}}
+    @metadataSchemaLoading={{this.metadataSchemaLoading}}
+    @registrationSchemaId={{this.registrationSchemaId}}
+    @exportCsvUrl={{this.exportCsvUrl}}
+/>
 
 {{#if this.node}}
     <Registries::PartialRegistrationModal::Manager

--- a/lib/registries/addon/drafts/draft/-components/right-nav/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/right-nav/template.hbs
@@ -18,6 +18,8 @@
 {{#if @navManager.inReview}}
     <Drafts::Draft::-Components::Register
         @draftManager={{@draftManager}}
+        @metadataSchema={{@metadataSchema}}
+        @metadataSchemaLoading={{@metadataSchemaLoading}}
         @onSubmitRedirect={{@onSubmitRedirect}}
     />
 {{/if}}

--- a/lib/registries/addon/drafts/draft/-components/top-nav/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/top-nav/template.hbs
@@ -63,6 +63,8 @@
             {{#if @navManager.inReview}}
                 <Drafts::Draft::-Components::Register
                     @draftManager={{@draftManager}}
+                    @metadataSchema={{@metadataSchema}}
+                    @metadataSchemaLoading={{@metadataSchemaLoading}}
                     @onSubmitRedirect={{action @onSubmitRedirect}}
                     @showMobileView={{true}}
                 />

--- a/lib/registries/addon/drafts/draft/review/template.hbs
+++ b/lib/registries/addon/drafts/draft/review/template.hbs
@@ -7,15 +7,6 @@
         <main
             {{did-insert this.markAndValidatedPages}}
         >
-            {{#if (and draftManager.hasInvalidResponses this.showMobileView)}}
-                <div
-                    data-test-invalid-responses-text
-                    local-class='WarningMessage'
-                    class='text-danger'
-                >
-                    {{t 'registries.drafts.draft.review.invalid_warning'}}
-                </div>
-            {{/if}}
             <Registries::RegistrationFormNavigationDropdown
                 @showMetadata={{false}}
                 @schemaBlocks={{draftManager.schemaBlocks}}

--- a/lib/registries/addon/drafts/draft/route.ts
+++ b/lib/registries/addon/drafts/draft/route.ts
@@ -10,6 +10,7 @@ import requireAuth from 'ember-osf-web/decorators/require-auth';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
 import MetadataNodeEradModel from 'ember-osf-web/models/metadata-node-erad';
 import MetadataNodeProjectModel from 'ember-osf-web/models/metadata-node-project';
+import MetadataNodeSchemaModel from 'ember-osf-web/models/metadata-node-schema';
 import NodeModel from 'ember-osf-web/models/node';
 import Analytics from 'ember-osf-web/services/analytics';
 import DraftRegistrationManager from 'registries/drafts/draft/draft-registration-manager';
@@ -18,6 +19,7 @@ import NavigationManager from 'registries/drafts/draft/navigation-manager';
 export interface DraftRouteModel {
     draftRegistrationManager: DraftRegistrationManager;
     navigationManager: NavigationManager;
+    metadataSchema: TaskInstance<MetadataNodeSchemaModel>;
 }
 
 @requireAuth()
@@ -58,6 +60,17 @@ export default class DraftRegistrationRoute extends Route {
         return { metadataNodeErad, metadataNodeProject };
     });
 
+    @task
+    loadMetadataSchema = task(function *(
+        this: DraftRegistrationRoute,
+        draftRegistrationAndNodeTask: TaskInstance<{draftRegistration: DraftRegistration, node: NodeModel}>,
+    ) {
+        const { node } = yield draftRegistrationAndNodeTask;
+        const metadataSchema: MetadataNodeSchemaModel = yield this.store
+            .findRecord('metadata-node-schema', node.id);
+        return metadataSchema;
+    });
+
     model(params: { id: string }): DraftRouteModel {
         const { id: draftId } = params;
         const draftRegistrationAndNodeTask = this.loadDraftRegistrationAndNode.perform(draftId);
@@ -66,10 +79,12 @@ export default class DraftRegistrationRoute extends Route {
             draftRegistrationAndNodeTask,
             metadataNodeTask,
         );
+        const metadataSchema = this.loadMetadataSchema.perform(draftRegistrationAndNodeTask);
         const navigationManager = new NavigationManager(draftRegistrationManager);
         return {
             navigationManager,
             draftRegistrationManager,
+            metadataSchema,
         };
     }
 

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -21,14 +21,13 @@
                         >
                             {{draftManager.node.title}} >
                         </OsfLink>
-                        <OsfLink
+                        <a
                             local-class='MetadataTitleName'
-                            @route='guid-node.metadata'
-                            @models={{array draftManager.node.id}}
+                            href='/{{draftManager.node.id}}/metadata'
                             style='color: white;'
                         >
                             {{t 'registries.drafts.draft.form.metadata_list'}}
-                        </OsfLink>
+                        </a>
                     </div>
                     <h1>
                         {{t 'registries.drafts.draft.form.new_registration'}}

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -34,6 +34,8 @@
                     @draftManager={{draftManager}}
                     @navManager={{navManager}}
                     @onSubmitRedirect={{this.onSubmitRedirect}}
+                    @metadataSchema={{this.model.metadataSchema.value}}
+                    @metadataSchemaLoading={{this.model.metadataSchema.isRunning}}
                 />
             {{/if}}
             <layout.leftNav as |leftNav|>
@@ -72,6 +74,8 @@
                             @navManager={{navManager}}
                             @draftManager={{draftManager}}
                             @onSubmitRedirect={{this.onSubmitRedirect}}
+                            @metadataSchema={{this.model.metadataSchema.value}}
+                            @metadataSchemaLoading={{this.model.metadataSchema.isRunning}}
                         />
                     </div>
                 </layout.right>

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -21,7 +21,14 @@
                         >
                             {{draftManager.node.title}} >
                         </OsfLink>
-                        <span local-class='MetadataTitleName'>{{t 'registries.drafts.draft.form.new_registration'}}></span>
+                        <OsfLink
+                            local-class='MetadataTitleName'
+                            @route='guid-node.metadata'
+                            @models={{array draftManager.node.id}}
+                            style='color: white;'
+                        >
+                            {{t 'registries.drafts.draft.form.metadata_list'}}
+                        </OsfLink>
                     </div>
                     <h1>
                         {{t 'registries.drafts.draft.form.new_registration'}}

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -24,6 +24,7 @@ import { iqbrimsStatus } from './views/iqbrims-status';
 import * as matlabProductNameList from './views/matlab-product-name-list';
 import { metadataNodeErad } from './views/metadata-node-erad';
 import { metadataNodeProject } from './views/metadata-node-project';
+import { metadataNodeSchemas } from './views/metadata-node-schemas';
 import { createNode } from './views/node';
 import { osfNestedResource, osfResource, osfToManyRelationship } from './views/osf-resource';
 import { getProviderSubjects } from './views/provider-subjects';
@@ -267,6 +268,7 @@ export default function(this: Server) {
     this.get('/project/:pid/binderhub/custom_base_image', customBaseImage.read);
     this.get('/project/:id/metadata/erad/candidates', metadataNodeErad);
     this.get('/project/:id/metadata/project', metadataNodeProject);
+    this.get('/project/:id/metadata/schemas', metadataNodeSchemas);
 
     this.urlPrefix = apiUrl;
     this.namespace = apiNamespace;

--- a/mirage/views/metadata-node-schemas.ts
+++ b/mirage/views/metadata-node-schemas.ts
@@ -1,0 +1,30 @@
+import { HandlerContext, Request } from 'ember-cli-mirage';
+
+export function metadataNodeSchemas(this: HandlerContext, _: any, request: Request) {
+    // Extract the node ID from the URL
+    const nodeId = request.params.id;
+
+    // Return a single metadata-node-schema object with formats and destinations
+    // This endpoint expects a single object response for findRecord
+    return {
+        data: {
+            id: nodeId,
+            type: 'metadata-node-schema',
+            attributes: {
+                formats: [
+                    {
+                        id: 'format-1',
+                        schema_id: '67408a3cf0d0a5000109c617',
+                        name: 'メタデータ共通項目2024版CSV形式 (日本語)',
+                    },
+                    {
+                        id: 'format-2',
+                        schema_id: '67408a3cf0d0a5000109c617',
+                        name: 'Common Metadata Elements 2024 edition CSV format (English)',
+                    },
+                ],
+                destinations: [],
+            },
+        },
+    };
+}

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -150,7 +150,8 @@ module('Registries | Acceptance | draft form', hooks => {
         assert.dom('[data-test-goto-previous-page]').isVisible();
         assert.dom('[data-test-goto-next-page]').doesNotExist();
         assert.dom('[data-test-goto-review]').doesNotExist();
-        assert.dom('[data-test-goto-register]').isVisible();
+        // GRDM-41018: Register button removed from project metadata editor
+        assert.dom('[data-test-goto-register]').doesNotExist();
     });
 
     test('right sidenav controls', async assert => {
@@ -205,7 +206,8 @@ module('Registries | Acceptance | draft form', hooks => {
         assert.dom('data-test-goto-next-page').doesNotExist();
         assert.dom('[data-test-goto-review]').doesNotExist();
 
-        assert.dom('[data-test-goto-register]').isVisible();
+        // GRDM-41018: Register button removed from project metadata editor
+        assert.dom('[data-test-goto-register]').doesNotExist();
         assert.dom('[data-test-goto-previous-page]').isVisible();
 
         // Can navigate back to the last page from review page
@@ -253,11 +255,14 @@ module('Registries | Acceptance | draft form', hooks => {
         await percySnapshot('Registries | Acceptance | draft form | mobile navigation | review page');
         assert.dom('[data-test-page-label]').containsText('Review');
         assert.dom('[data-test-goto-next-page]').isNotVisible();
-        assert.dom('[data-test-goto-register]').isVisible();
+        // GRDM-41018: Register button removed from project metadata editor
+        assert.dom('[data-test-goto-register]').doesNotExist();
 
         // check that register button is disabled
-        assert.dom('[data-test-goto-register]').isDisabled();
-        assert.dom('[data-test-invalid-responses-text]').isVisible();
+        // GRDM-41018: Register button removed from project metadata editor
+        assert.dom('[data-test-goto-register]').doesNotExist();
+        // GRDM-41018: Invalid responses text removed with registration functionality
+        // assert.dom('[data-test-invalid-responses-text]').isVisible();
 
         // Check that back button works
         await click('[data-test-goto-previous-page]');
@@ -289,8 +294,10 @@ module('Registries | Acceptance | draft form', hooks => {
 
         await visit(`/registries/drafts/${registration.id}/review`);
         assert.ok(currentURL().includes(`/registries/drafts/${registration.id}/review`), 'At review page');
-        assert.dom('[data-test-goto-register]').isDisabled();
-        assert.dom('[data-test-invalid-responses-text]').isVisible();
+        // GRDM-41018: Register button removed from project metadata editor
+        assert.dom('[data-test-goto-register]').doesNotExist();
+        // GRDM-41018: Invalid responses text removed with registration functionality
+        // assert.dom('[data-test-invalid-responses-text]').isVisible();
     });
 
     test('validations: errors show on review page', async assert => {
@@ -344,8 +351,10 @@ module('Registries | Acceptance | draft form', hooks => {
 
         await click('[data-test-link="review"]');
 
-        assert.dom('[data-test-goto-register]').isDisabled();
-        assert.dom('[data-test-invalid-responses-text]').isVisible();
+        // GRDM-41018: Register button removed from project metadata editor
+        assert.dom('[data-test-goto-register]').doesNotExist();
+        // GRDM-41018: Invalid responses text removed with registration functionality
+        // assert.dom('[data-test-invalid-responses-text]').isVisible();
     });
 
     /* metadata addon: disable metadata page
@@ -380,42 +389,11 @@ module('Registries | Acceptance | draft form', hooks => {
         registration.update({ subjects });
         await visit(`/registries/drafts/${registration.id}/review`);
         assert.ok(currentURL().includes(`/registries/drafts/${registration.id}/review`), 'At review page');
-        assert.dom('[data-test-goto-register]').isNotDisabled();
+        // GRDM-41018: Register button removed from project metadata editor
+        assert.dom('[data-test-goto-register]').doesNotExist();
 
-        await click('[data-test-goto-register]');
-        await settled();
-
-        // PartialRegistrationModal
-        assert.dom('#osf-dialog-heading').hasText(t('registries.partialRegistrationModal.title').toString());
-        [rootNode, childNode, grandChildNode].mapBy('id').forEach(id => assert.dom(`[data-test-expand-child="${id}"]`));
-        await click('[data-test-cancel-registration-button]');
-        await settled();
-        assert.dom('#osf-dialog-heading').isNotVisible('cancel closes the modal');
-
-        await click('[data-test-goto-register]');
-        await settled();
-        assert.dom('[data-test-continue-registration-button]').isVisible();
-        await click('[data-test-continue-registration-button]');
-
-        // FinalizeRegistrationModal
-        assert.dom('#osf-dialog-heading').hasText(t('registries.finalizeRegistrationModal.title').toString());
-        assert.dom('[data-test-submit-registration-button]').isDisabled();
-
-        await click('[data-test-back-button]');
-        assert.dom('#osf-dialog-heading').hasText(
-            t('registries.partialRegistrationModal.title').toString(),
-            'back button switches to partialRegistrationModal',
-        );
-
-        await click('[data-test-continue-registration-button]');
-
-        await click('[data-test-immediate-button]');
-        assert.dom('[data-test-submit-registration-button]').isNotDisabled();
-
-        await click('[data-test-submit-registration-button]');
-        await settled();
-
-        assert.equal(currentRouteName(), 'registries.overview.index', 'Redicted to new registration overview page');
+        // GRDM-41018: Registration functionality removed from project metadata editor
+        // All registration modal tests have been removed as the register button no longer exists
     });
     */
 
@@ -537,7 +515,8 @@ module('Registries | Acceptance | draft form', hooks => {
         await click('[data-test-link="review"]');
         assert.dom('[data-test-link="metadata"] > [data-test-icon]')
             .hasClass('fa-exclamation-circle', 'metadata page is marked invalid');
-        assert.dom('[data-test-goto-register]').isDisabled();
+        // GRDM-41018: Register button removed from project metadata editor
+        assert.dom('[data-test-goto-register]').doesNotExist();
         assert.dom('[data-test-validation-errors="subjects"]');
         assert.dom('[data-test-validation-errors="license"]');
 

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -654,6 +654,7 @@ node:
         new: 'Create new metadata'
         reports: Metadata
         draft_reports: 'Draft Metadata'
+        registrations: Registered Metadata(Locked)
 delete_modal:
     title: 'Are you sure you want to delete this {nodeType}?'
     body: 'It will no longer be available to other contributors on the {nodeType}.'
@@ -1038,7 +1039,6 @@ registries:
                 title: 'Review registration before submitting'
                 page_label: Review
                 start_review: Review
-                invalid_warning: 'Please address invalid or missing entries to complete registration.'
                 toggle_dropdown: 'Toggle navigation dropdown'
             register: Register
             submit_error: 'Unable to create a registration.'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -648,13 +648,13 @@ node:
             create: 'Create Metadata'
         page_title: '{nodeTitle} Metadata'
         only_contributors_with_write_permission_can_initiate: 'Only contributors with write permission can initiate metadata.'
-        no_reports: 'There are no metadata of this project.'
+        no_reports: 'There are no editable project metadata in this project.'
         no_drafts: 'There are no draft metadata of this project.'
-        start_new: 'Start to edit a new metadata by clicking the “Create new metadata” button. Once created, metadata cannot be edited or deleted.'
+        start_new: 'Start to edit a new metadata by clicking the "Create new metadata" button.'
         new: 'Create new metadata'
         reports: Metadata
         draft_reports: 'Draft Metadata'
-        registrations: Registered Metadata(Locked)
+        registrations: Frozen Metadata(Locked)
 delete_modal:
     title: 'Are you sure you want to delete this {nodeType}?'
     body: 'It will no longer be available to other contributors on the {nodeType}.'
@@ -1007,7 +1007,7 @@ registries:
         help:
             title: 'Help Choose Registration Form'
     drafts:
-        page_title: 'View Registration Drafts'
+        page_title: 'View Project Metadata'
         index:
             title: 'Choose Unfinished Draft'
         draft:
@@ -1018,11 +1018,11 @@ registries:
                 save_institutions_error: 'Failed to save affiliated institutions'
                 load_institutions_error: 'Failed to load affiliated institutions'
             form:
-                title: 'Fill out registration form'
+                title: 'Fill out metadata form'
                 next: Next
                 back: Back
                 save_draft: 'Save draft'
-                new_registration: 'Register Project Metadata'
+                new_registration: 'Edit Project Metadata'
                 metadata_list: 'Project Metadata List'
                 last_saved: 'Auto-saved: '
                 save_failed: 'Save failed. Unsaved changes present.'
@@ -1038,7 +1038,7 @@ registries:
                 clipboard_unread: 'Failed to read from clipboard: '
             edit_complete: 'Edit Complete'
             review:
-                title: 'Review registration before submitting'
+                title: 'Review content'
                 page_label: Review
                 start_review: Review
                 toggle_dropdown: 'Toggle navigation dropdown'
@@ -1386,7 +1386,7 @@ osf-components:
         started: 'Started:'
         last_updated: 'Last updated:'
         review: Review
-        delete_draft_confirm: 'Are you sure you want to delete this draft registration?'
+        delete_draft_confirm: 'Are you sure you want to delete this project metadata?'
     copyable-text:
         copyToClipboard: 'Copy to clipboard'
         copied: Copied

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1023,6 +1023,7 @@ registries:
                 back: Back
                 save_draft: 'Save draft'
                 new_registration: 'Register Project Metadata'
+                metadata_list: 'Project Metadata List'
                 last_saved: 'Auto-saved: '
                 save_failed: 'Save failed. Unsaved changes present.'
                 failed_auto_save: 'Failed to auto-save draft registration form'
@@ -1035,6 +1036,7 @@ registries:
                 clipboard_fail: 'Failed to save from clipboard: '
                 json_invalid: 'Clipboard does not contain valid JSON: '
                 clipboard_unread: 'Failed to read from clipboard: '
+            edit_complete: 'Edit Complete'
             review:
                 title: 'Review registration before submitting'
                 page_label: Review

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -654,6 +654,7 @@ node:
         new: 新規メタデータを作成
         reports: メタデータ
         draft_reports: 下書き
+        registrations: 登録済みメタデータ(編集不可)
 delete_modal:
     title: 'この{nodeType}を削除してもよろしいですか？'
     body: '{nodeType}の他の投稿者は利用できなくなります。'
@@ -1038,7 +1039,6 @@ registries:
                 title: 送信前に登録を確認する
                 page_label: 内容確認
                 start_review: 内容確認
-                invalid_warning: 'メタデータを登録するには、各項目に正しい内容を入力してください。'
                 toggle_dropdown: 'Toggle navigation dropdown'
             register: 登録
             submit_error: 'Unable to create a registration.'

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -1023,6 +1023,7 @@ registries:
                 back: 戻る
                 save_draft: 'ドラフトを保存'
                 new_registration: 'プロジェクトメタデータの登録'
+                metadata_list: 'プロジェクトメタデータ一覧'
                 last_saved: '自動保存済み: '
                 save_failed: '保存に失敗しました。保存できていない変更があります。'
                 failed_auto_save: '下書きの自動保存に失敗しました。'
@@ -1035,6 +1036,7 @@ registries:
                 clipboard_fail: 'クリップボードからの保存に失敗しました: '
                 json_invalid: 'クリップボードには有効な JSON が含まれていません: '
                 clipboard_unread: 'クリップボードからの読み取りに失敗しました: '
+            edit_complete: '編集完了'
             review:
                 title: 送信前に登録を確認する
                 page_label: 内容確認

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -648,13 +648,13 @@ node:
             create: メタデータを作成
         page_title: '{nodeTitle} メタデータ'
         only_contributors_with_write_permission_can_initiate: 'プロジェクトの書き込み権限を持つメンバーのみがメタデータ編集を実施できます。'
-        no_reports: このプロジェクトのメタデータはありません。
+        no_reports: このプロジェクトにおける編集可能なプロジェクトメタデータはありません。
         no_drafts: このプロジェクトに関する下書きはありません。
-        start_new: '「新規メタデータを作成」ボタンをクリックして、新規メタデータ作成を開始します。一度登録したメタデータを、編集または削除することはできません。'
+        start_new: '「新規メタデータを作成」ボタンをクリックして、新規メタデータ作成を開始します。'
         new: 新規メタデータを作成
         reports: メタデータ
         draft_reports: 下書き
-        registrations: 登録済みメタデータ(編集不可)
+        registrations: 凍結済みメタデータ(編集不可)
 delete_modal:
     title: 'この{nodeType}を削除してもよろしいですか？'
     body: '{nodeType}の他の投稿者は利用できなくなります。'
@@ -1007,7 +1007,7 @@ registries:
         help:
             title: 登録フォームの選択を支援
     drafts:
-        page_title: 下書きを表示
+        page_title: プロジェクトメタデータを表示
         index:
             title: 未完成の下書きを選択
         draft:
@@ -1018,11 +1018,11 @@ registries:
                 save_institutions_error: 'Failed to save affiliated institutions'
                 load_institutions_error: 'Failed to load affiliated institutions'
             form:
-                title: 登録フォームに記入
+                title: メタデータフォームに記入
                 next: 次へ
                 back: 戻る
                 save_draft: 'ドラフトを保存'
-                new_registration: 'プロジェクトメタデータの登録'
+                new_registration: 'プロジェクトメタデータの編集'
                 metadata_list: 'プロジェクトメタデータ一覧'
                 last_saved: '自動保存済み: '
                 save_failed: '保存に失敗しました。保存できていない変更があります。'
@@ -1038,7 +1038,7 @@ registries:
                 clipboard_unread: 'クリップボードからの読み取りに失敗しました: '
             edit_complete: '編集完了'
             review:
-                title: 送信前に登録を確認する
+                title: 内容を確認する
                 page_label: 内容確認
                 start_review: 内容確認
                 toggle_dropdown: 'Toggle navigation dropdown'
@@ -1386,7 +1386,7 @@ osf-components:
         started: '開始日:'
         last_updated: '最終更新日:'
         review: 内容確認
-        delete_draft_confirm: この下書きを削除してもよろしいですか？
+        delete_draft_confirm: このプロジェクトメタデータを削除してもよろしいですか？
     copyable-text:
         copyToClipboard: クリップボードへコピー
         copied: コピー済み


### PR DESCRIPTION
(https://github.com/RCOSDP/RDM-ember-osf-web/pull/144 の適用後に適用する想定です。)

- Ticket: GRDM-41018
- Feature flag: n/a

## Purpose

プロジェクトメタデータにてRegistration化をしないようにする

## Summary of Changes

- プロジェクトメタデータにてRegistration化をしないように、メタデータ編集最終段階の 登録 ボタンを エクスポート ボタンに差し替え
- プロジェクトメタデータ一覧画面の メタデータ / 下書き タブを廃止。下書きは優先的に 編集可能なプロジェクトメタデータ として表示し、登録ずみデータは凍結済み(編集不可)と文言変更
  - プロジェクトメタデータ各項目のタイトル表示は、 project-name-ja, project-name-en (公的資金〜メタデータ), title-of-dataset, title-of-dataset-en (未病メタデータ) の順で解決。いずれもなければ従来通りGRDMプロジェクト名

- プロジェクトメタデータ一覧画面に戻るための経路として、
  -  画面上部のパンくず部分を、 プロジェクト名>プロジェクトメタデータ一覧> とし、プロジェクトメタデータ一覧に戻れるように変更
  - メタデータ編集最終段階において 編集完了 ボタンを新設

## Side Effects

None

## QA Notes

None