### PR TITLE
未病データベース-カタログ登録機能追加（develop）

### DIFF
--- a/app/models/registration-schema.ts
+++ b/app/models/registration-schema.ts
@@ -31,6 +31,7 @@ export interface Page {
     questions: Question[];
     type?: 'object';
     description?: string;
+    clipboardCopyPaste: boolean;
 }
 
 export interface Schema {

--- a/app/models/schema-block.ts
+++ b/app/models/schema-block.ts
@@ -22,6 +22,15 @@ export default class SchemaBlockModel extends OsfModel implements SchemaBlock {
     @attr('number') index?: number;
     @attr('string') pattern?: string;
     @attr('boolean') spaceNormalization?: boolean;
+    @attr('string') retrievalTitle?: string;
+    @attr('string') retrievalDate?: string;
+    @attr('boolean') concealmentPageNavigator?: boolean;
+    @attr('string') requiredAllCheck?: string;
+    @attr('boolean') multiLanguage?: boolean;
+    @attr('string') retrievalVersion?: string;
+    @attr('boolean') readonly?: boolean;
+    @attr('boolean') sentence?: boolean;
+    @attr('string') rowAdditionCaption?: string;
 
     @belongsTo('registration-schema', { inverse: 'schemaBlocks', async: false })
     schema?: RegistrationSchemaModel;

--- a/app/packages/registration-schema/get-pages.ts
+++ b/app/packages/registration-schema/get-pages.ts
@@ -4,13 +4,15 @@ export function getPages(blocks: SchemaBlock[]) {
     const pageArray = blocks.reduce(
         (pages, block) => {
             // instantiate first page if the schema doesn't start with a page-heading
-            if (pages.length === 0 && block.blockType !== 'page-heading') {
+            if (pages.length === 0 && block.blockType !== 'page-heading'
+                && (block.concealmentPageNavigator === true || block.concealmentPageNavigator === undefined)) {
                 const blankPage: SchemaBlock[] = [];
                 pages.push(blankPage);
             }
 
             const lastPage: SchemaBlock[] = pages.slice(-1)[0];
-            if (block.blockType === 'page-heading') {
+            if (block.blockType === 'page-heading'
+                && (block.concealmentPageNavigator === false || block.concealmentPageNavigator === undefined)) {
                 pages.push([block]);
             } else {
                 lastPage.push(block);

--- a/app/packages/registration-schema/get-schema-block-group.ts
+++ b/app/packages/registration-schema/get-schema-block-group.ts
@@ -43,6 +43,8 @@ export function getSchemaBlockGroups(blocks: SchemaBlock[] | undefined) {
             case 'jgn-program-name-ja-input':
             case 'jgn-program-name-en-input':
             case 'e-rad-award-funder-input':
+            case 'single-select-pulldown-input':
+            case 'pulldown-input':
             case 'e-rad-award-number-input':
             case 'e-rad-award-title-ja-input':
             case 'e-rad-award-title-en-input':
@@ -52,6 +54,7 @@ export function getSchemaBlockGroups(blocks: SchemaBlock[] | undefined) {
             case 'e-rad-researcher-name-en-input':
             case 'e-rad-bunnya-input':
             case 'file-metadata-input':
+            case 'ad-metadata-input':
             case 'date-input':
             case 'section-heading':
             case 'subsection-heading':

--- a/app/packages/registration-schema/index.ts
+++ b/app/packages/registration-schema/index.ts
@@ -2,7 +2,12 @@ export { getPages } from './get-pages';
 export { getSchemaBlockGroups } from './get-schema-block-group';
 export { SchemaBlock, SchemaBlockType } from './schema-block';
 export { SchemaBlockGroup } from './schema-block-group';
-export { buildValidation, buildMetadataValidations, setupEventForSyncValidation } from './validations';
+export {
+    buildValidation,
+    buildMetadataValidations,
+    setupEventForSyncValidation,
+    setupEventForSyncValidation2,
+} from './validations';
 export {
     FileReference,
     RegistrationResponse,

--- a/app/packages/registration-schema/page-manager.ts
+++ b/app/packages/registration-schema/page-manager.ts
@@ -10,6 +10,7 @@ import {
     SchemaBlock,
     SchemaBlockGroup,
     setupEventForSyncValidation,
+    setupEventForSyncValidation2,
 } from 'ember-osf-web/packages/registration-schema';
 import { RegistrationResponse } from 'ember-osf-web/packages/registration-schema/registration-response';
 
@@ -17,12 +18,14 @@ export class PageManager {
     changeset?: ChangesetDef;
     schemaBlockGroups?: SchemaBlockGroup[];
     pageHeadingText?: string;
+    concealmentPageNavigator?: boolean;
     isVisited?: boolean;
 
     constructor(pageSchemaBlocks: SchemaBlock[], registrationResponses: RegistrationResponse, node?: NodeModel) {
         this.schemaBlockGroups = getSchemaBlockGroups(pageSchemaBlocks);
         if (this.schemaBlockGroups) {
             this.pageHeadingText = this.schemaBlockGroups[0].labelBlock!.displayText!;
+            this.concealmentPageNavigator = this.schemaBlockGroups[0].labelBlock!.concealmentPageNavigator!;
 
             this.isVisited = this.schemaBlockGroups.some(
                 ({ registrationResponseKey: key }) => Boolean(key && (key in registrationResponses)),
@@ -34,7 +37,10 @@ export class PageManager {
                 lookupValidator(validations),
                 validations,
             ) as ChangesetDef;
+
             setupEventForSyncValidation(this.changeset, this.schemaBlockGroups);
+
+            setupEventForSyncValidation2(this.changeset, this.schemaBlockGroups);
 
             if (this.isVisited) {
                 this.changeset.validate();

--- a/app/packages/registration-schema/schema-block.ts
+++ b/app/packages/registration-schema/schema-block.ts
@@ -17,6 +17,8 @@ export type SchemaBlockType =
     'jgn-program-name-ja-input' |
     'jgn-program-name-en-input' |
     'e-rad-award-funder-input' |
+    'single-select-pulldown-input' |
+    'pulldown-input' |
     'e-rad-award-number-input' |
     'e-rad-award-title-ja-input' |
     'e-rad-award-title-en-input' |
@@ -26,6 +28,7 @@ export type SchemaBlockType =
     'e-rad-researcher-name-en-input' |
     'e-rad-bunnya-input' |
     'file-metadata-input' |
+    'ad-metadata-input' |
     'date-input' |
     'array-input';
 
@@ -43,4 +46,12 @@ export interface SchemaBlock {
     index?: number;
     pattern?: string;
     spaceNormalization?: boolean;
+    hideProjectmetadata?: boolean;
+    retrievalTitle?: string;
+    retrievalDate?: string;
+    concealmentPageNavigator?: boolean;
+    requiredAllCheck?: string;
+    multiLanguage?: boolean;
+    retrievalVersion?: string;
+    rowAdditionCaption?: string;
 }

--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -58,9 +58,19 @@ export function buildValidation(groups: SchemaBlockGroup[], node?: NodeModel) {
                 );
             }
             if (inputBlock.requiredIf) {
-                validationForResponse.push(
-                    validateRequiredIf(inputBlock.requiredIf, groups),
-                );
+                if (inputBlock.requiredIf.startsWith('{') && inputBlock.requiredIf.endsWith('}')) {
+                    const jsonString = inputBlock.requiredIf.replace(/'/g, '"');
+                    const requiredIfObject = JSON.parse(jsonString);
+                    const requiredIf = Object.keys(requiredIfObject)[0];
+                    const requiredifValue = requiredIfObject[requiredIf];
+                    validationForResponse.push(
+                        validateRequiredIf(requiredIf, requiredifValue, groups),
+                    );
+                } else {
+                    validationForResponse.push(
+                        validateRequiredIf(inputBlock.requiredIf, '', groups),
+                    );
+                }
             }
             if (inputBlock.pattern) {
                 const key = (group.registrationResponseKey || '').substr('__responseKey_'.length);
@@ -99,12 +109,31 @@ export function setupEventForSyncValidation(changeset: ChangesetDef, groups: Sch
     changeset.on('afterValidation', (key: string) => {
         requiredIfGroups
             .forEach(group => {
-                if (`__responseKey_${group.inputBlock!.requiredIf}` !== key) {
+                let requiredIf;
+                let requiredifValue;
+                let condition;
+                let messageType: string;
+                const contextCurrentValue = changeset.get(key);
+
+                if (group.inputBlock!.requiredIf!.startsWith('{') && group.inputBlock!.requiredIf!.endsWith('}')) {
+                    const jsonString = group.inputBlock!.requiredIf!.replace(/'/g, '"');
+                    const requiredIfObject = JSON.parse(jsonString);
+                    [requiredIf] = Object.keys(requiredIfObject);
+                    requiredifValue = requiredIfObject[requiredIf];
+
+                    messageType = 'invalid_required_if_object';
+                    condition = !contextCurrentValue || contextCurrentValue === requiredifValue;
+                } else {
+                    requiredIf = group.inputBlock!.requiredIf;
+                    messageType = 'invalid_required_if';
+                    condition = !contextCurrentValue;
+                }
+
+                if (`__responseKey_${requiredIf}` !== key) {
                     return;
                 }
                 const errors = changeset.get('errors');
                 const otherKey = group.registrationResponseKey as string;
-                const contextCurrentValue = changeset.get(key);
                 const validationErrors = errors
                     .filter((error: any) => error.key === otherKey)
                     .flatMap((error: any) => error.validation as Array<string | ValidationResult>)
@@ -112,7 +141,7 @@ export function setupEventForSyncValidation(changeset: ChangesetDef, groups: Sch
                         (result: string | ValidationResult): result is ValidationResult => typeof result === 'object',
                     )
                     .filter(
-                        (result: ValidationResult) => result.context.type === 'invalid_required_if',
+                        (result: ValidationResult) => result.context.type === messageType,
                     );
                 const validatedContextValues: Array<{[key: string]: any}> = validationErrors
                     .filter((result: ValidationResult) => typeof result.value === 'object')
@@ -124,10 +153,52 @@ export function setupEventForSyncValidation(changeset: ChangesetDef, groups: Sch
                     changeset.validate(otherKey);
                     return;
                 }
-                if (!contextCurrentValue && !validatedContextValues.filter(values => !values[key]).length) {
+
+                if ((condition) && !validatedContextValues.filter(values => !values[key]).length) {
                     changeset.validate(otherKey);
                 }
             });
+    });
+}
+
+export function setupEventForSyncValidation2(changeset: ChangesetDef, groups: SchemaBlockGroup[]) {
+    const requiredAllCheckGroups = groups
+        // ignore GRDM file specific fields
+        .filter((group: SchemaBlockGroup) => !group.registrationResponseKey
+            || !group.registrationResponseKey.match(/^__responseKey_grdm-file:.+$/))
+        .filter((group: SchemaBlockGroup) => group.inputBlock && group.inputBlock.requiredAllCheck);
+
+    let isProcesing = false;
+
+    changeset.on('afterValidation', () => {
+        if (isProcesing) {
+            return;
+        }
+        isProcesing = true;
+
+        try {
+            const checkboxList = requiredAllCheckGroups.map(group => {
+                const registrationResponseKey: string = group.registrationResponseKey || '';
+                const value = changeset.get(registrationResponseKey);
+                return Array.isArray(value) && value.length === 1;
+            });
+
+            requiredAllCheckGroups
+                .forEach(group => {
+                    if (!checkboxList.includes(false)) {
+                        const todayDate = `${new Date().getFullYear()}/${
+                            String(new Date().getMonth() + 1).padStart(2, '0')
+                        }/${
+                            String(new Date().getDate()).padStart(2, '0')
+                        }`;
+                        changeset.set(`__responseKey_${group.inputBlock!.requiredAllCheck}`, todayDate);
+                    } else {
+                        changeset.set(`__responseKey_${group.inputBlock!.requiredAllCheck}`, '');
+                    }
+                });
+        } finally {
+            isProcesing = false;
+        }
     });
 }
 

--- a/app/validators/validate-response-format.ts
+++ b/app/validators/validate-response-format.ts
@@ -45,7 +45,7 @@ export function validateFileList(responseKey: string, node?: NodeModel): Validat
 }
 
 export function validateRequiredIf(
-    requiredIf: string, groups: SchemaBlockGroup[],
+    requiredIf: string, enabledifValue: string, groups: SchemaBlockGroup[],
 ): ValidatorFunction {
     return async (
         key: string,
@@ -63,13 +63,24 @@ export function validateRequiredIf(
         const displayText: string = (otherGroup && otherGroup.labelBlock && otherGroup.labelBlock.displayText) || '';
         const otherValues = { ...content, ...changes } as {[key: string]: string};
         const otherValue = otherValues[otherKey];
-        if (!newValue && !otherValue) {
+        let conditionMet;
+        let messageType;
+        if (enabledifValue === '') {
+            conditionMet = !newValue && !otherValue;
+            messageType = 'invalid_required_if';
+        } else {
+            conditionMet = (!newValue && !otherValue) || (!newValue && otherValue === enabledifValue);
+            messageType = 'invalid_required_if_object';
+        }
+
+        if (conditionMet) {
             return buildMessage(key, {
                 type: 'presence',
                 context: {
-                    type: 'invalid_required_if',
+                    type: messageType,
                     translationArgs: {
                         otherLabel: displayText,
+                        selectedValue: enabledifValue,
                     },
                 },
                 value: {

--- a/lib/osf-components/addon/components/osf-layout/registries-side-nav/component.ts
+++ b/lib/osf-components/addon/components/osf-layout/registries-side-nav/component.ts
@@ -5,7 +5,12 @@ import { and, or } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Media from 'ember-responsive';
 
+import DS from 'ember-data';
+import Intl from 'ember-intl/services/intl';
 import { layout } from 'ember-osf-web/decorators/component';
+import DraftRegistration from 'ember-osf-web/models/draft-registration';
+import CurrentUser from 'ember-osf-web/services/current-user';
+import Toast from 'ember-toastr/services/toast';
 
 import styles from './styles';
 import template from './template';
@@ -13,7 +18,16 @@ import template from './template';
 @tagName('')
 @layout(template, styles)
 export default class RegistriesSideNav extends Component {
+    @service store!: DS.Store;
+    draftRegistrations: DraftRegistration[] = [];
+    // registrationSchema: RegistrationSchema[] = [];
+    @service toast!: Toast;
+    format?: string = '';
+
     @service media!: Media;
+    @service intl!: Intl;
+    @service currentUser!: CurrentUser;
+    // changeset!: ChangesetDef;
 
     // Optional params
     onLinkClicked?: () => void;
@@ -27,8 +41,84 @@ export default class RegistriesSideNav extends Component {
     @and('isCollapseAllowed', 'shouldCollapse')
     isCollapsed!: boolean;
 
+    @service router!: any;
+    disableButtons = false;
+    pageTitle = '';
+    jsonData = '';
+
+    constructor(...args: any[]) {
+        super(...args);
+        this.handleRouteChange();
+        if (this.router && typeof this.router.on === 'function') {
+            this.router.on('routeDidChange', this.handleRouteChange.bind(this));
+        }
+    }
+
     @action
     toggle() {
         this.toggleProperty('shouldCollapse');
+    }
+
+    @action
+    async handleRouteChange() {
+        const currentUrl = window.location.href;
+        const urlParts = currentUrl.split('/');
+        const lastPartWithQuery = urlParts[urlParts.length - 1];
+        const metadataTitle = lastPartWithQuery.split('?')[0];
+        const cleanedTitle = metadataTitle.replace(/^\d+-/, '');
+        const title = decodeURIComponent(cleanedTitle.replace(/-/g, ' '));
+        this.set('pageTitle', title.trim().toLowerCase());
+        const allSchemas = await this.store.findAll('registration-schema');
+        const matchedSchema = allSchemas.find((schema: any) => schema.schema.pages.some((page: any) => (
+            page.title.trim().toLowerCase() === title.trim().toLowerCase()
+            && page.clipboardCopyPaste === false)));
+
+        if (matchedSchema) {
+            this.set('disableButtons', true);
+        } else {
+            this.set('disableButtons', false);
+        }
+    }
+
+    @action
+    async copyToClipboard() {
+        const currentUrl = window.location.href;
+        const idRegex = /\/drafts\/([a-f0-9]{24})/;
+        const match = currentUrl.match(idRegex);
+        if (match && match[1]) {
+            const draftId = match[1];
+
+            const draftRegistration = await this.store.findRecord('draft-registration', draftId);
+
+            if (draftRegistration) {
+                const registrationMetadata = await draftRegistration.registrationMetadata;
+                const metadata: { [key: string]: any } = {};
+                const registrationSchema = await draftRegistration.registrationSchema;
+                for (const page of registrationSchema.schema.pages) {
+                    if (page.title.trim().toLowerCase() !== this.pageTitle && !page.clipboardCopyPaste) {
+                        continue;
+                    }
+
+                    for (const question of page.questions) {
+                        Object.keys(registrationMetadata).forEach(key => {
+                            if (key === question.qid && !key.startsWith('grdm-')) {
+                                if (question.format === 'multiselect' && registrationMetadata[key].value === '') {
+                                    metadata[key] = [];
+                                } else {
+                                    metadata[key] = registrationMetadata[key].value;
+                                }
+                            }
+                        });
+                    }
+                }
+                this.jsonData = JSON.stringify(metadata);
+                if (this.jsonData === '{}' || Object.keys(JSON.parse(this.jsonData)).length === 0) {
+                    this.toast.warning(this.intl.t('registries.drafts.draft.form.warning_noautosave'));
+                } else {
+                    await navigator.clipboard.writeText(this.jsonData);
+                    this.toast.success(this.intl.t('registries.drafts.draft.form.clipboard_copied'));
+                }
+            }
+        }
     }
 }

--- a/lib/osf-components/addon/components/osf-layout/registries-side-nav/label/styles.scss
+++ b/lib/osf-components/addon/components/osf-layout/registries-side-nav/label/styles.scss
@@ -1,10 +1,11 @@
 .LabelWrapper {
     justify-content: space-between;
-    display: inline-flex;
+    display: flex;
     width: 100%;
     padding-left: 10px;
     font-weight: 700;
-    white-space: inherit;
+    white-space: normal;
+    word-wrap: break-word;
     overflow: hidden;
 
     &:hover {
@@ -16,6 +17,8 @@
     float: left;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: normal;
+    word-wrap: break-word;
 
     &:hover {
         overflow: visible;
@@ -24,4 +27,7 @@
 
 .Count {
     float: right;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }

--- a/lib/osf-components/addon/components/osf-layout/registries-side-nav/template.hbs
+++ b/lib/osf-components/addon/components/osf-layout/registries-side-nav/template.hbs
@@ -38,4 +38,23 @@
             </ExpandButton>
         {{/let}}
     {{/if}}
+
+    {{!-- model1 :{{@model}}
+    model2 : {{model}}
+    {{#each @model as |item index|}}
+        {{#if (eq index 1)}}
+            <p>test >>{{item}}</p>
+        {{/if}}
+    {{/each}}   
+    test --}}
+    <OsfButton
+        data-test-copy-to-clipboard
+        data-analytics-name='Copy to clipboard'
+        @onClick={{action this.copyToClipboard}}
+        @disabled={{this.disableButtons}}
+        @type='info'
+    >
+        {{t 'registries.drafts.draft.form.copy_to_clipboard'}}
+    </OsfButton>
+
 </nav>

--- a/lib/osf-components/addon/components/registries/registration-form-navigation-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/registries/registration-form-navigation-dropdown/template.hbs
@@ -60,16 +60,18 @@
                     {{/each}}
                 {{/if}}
                 {{#each this.localizedBlocksWithAnchor as |block|}}
-                    <li local-class='{{block.model.blockType}}' data-test-list-item='{{block.model.blockType}}'>
-                        <OsfLink
-                            data-test-page-anchor={{block.model.elementId}}
-                            data-analytics-name='Go to {{block.model.blockType}}: {{block.localizedDisplayText}}'
-                            @href='#{{block.model.elementId}}'
-                            @onClick={{action dd.close}}
-                        >
-                            {{block.localizedDisplayText}}
-                        </OsfLink>
-                    </li>
+                    {{#unless block.model.concealmentPageNavigator}}
+                        <li local-class='{{block.model.blockType}}' data-test-list-item='{{block.model.blockType}}'>
+                            <OsfLink
+                                data-test-page-anchor={{block.model.elementId}}
+                                data-analytics-name='Go to {{block.model.blockType}}: {{block.localizedDisplayText}}'
+                                @href='#{{block.model.elementId}}'
+                                @onClick={{action dd.close}}
+                            >
+                                {{block.localizedDisplayText}}
+                            </OsfLink>
+                        </li>
+                    {{/unless}}
                 {{/each}}
             </ol>
         </nav>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
@@ -1,13 +1,15 @@
-<p
-    data-test-files-instructions
-    local-class='FilesInstructions'
->
-    {{t 'osf-components.registries.schema-block-renderer/editable/files.instructions'
-        projectOrComponent=(if @node.isRoot 'project' 'component')
-        nodeUrl=this.nodeUrl
-        htmlSafe=true
-    }}
-</p>
+{{#if (not @schemaBlock.sentence)}}
+    <p
+        data-test-files-instructions
+        local-class='FilesInstructions'
+    >
+        {{t 'osf-components.registries.schema-block-renderer/editable/files.instructions'
+            projectOrComponent=(if @node.isRoot 'project' 'component')
+            nodeUrl=this.nodeUrl
+            htmlSafe=true
+        }}
+    </p>
+{{/if}}
 <Files::SelectedList
     local-class='SelectedList'
     @selectedFiles={{this.selectedFiles}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
@@ -29,6 +29,14 @@
         'registries/schema-block-renderer/editable/text'
         changeset=@changeset
         onInput=@onInput
+        node=@node
+        draftManager=@draftManager
+    )
+    date-input=(
+        component
+        'registries/schema-block-renderer/editable/date'
+        changeset=@changeset
+        onInput=@onInput
     )
     long-text-input=(
         component
@@ -114,6 +122,24 @@
         node=@node
         metadataNodeErad=@metadataNodeErad
     )
+    single-select-pulldown-input=(
+        component
+        'registries/schema-block-renderer/editable/rdm/single-select-pulldown-input'
+        changeset=@changeset
+        onInput=@onInput
+        onMetadataInput=@onMetadataInput
+        node=@node
+        metadataNodeErad=@metadataNodeErad
+    )    
+    pulldown-input=(
+        component
+        'registries/schema-block-renderer/editable/rdm/pulldown-input'
+        changeset=@changeset
+        onInput=@onInput
+        onMetadataInput=@onMetadataInput
+        node=@node
+        metadataNodeErad=@metadataNodeErad
+    )
     e-rad-award-number-input=(
         component
         'registries/schema-block-renderer/editable/rdm/e-rad-award-number-input'
@@ -158,6 +184,15 @@
     file-metadata-input=(
         component
         'registries/schema-block-renderer/editable/rdm/file-metadata-input'
+        changeset=@changeset
+        onInput=@onInput
+        node=@node
+        metadataNodeProject=@metadataNodeProject
+        draftManager=@draftManager
+    )
+    ad-metadata-input=(
+        component
+        'registries/schema-block-renderer/editable/rdm/ad-metadata-input'
         changeset=@changeset
         onInput=@onInput
         node=@node

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/ad-metadata-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/ad-metadata-input/component.ts
@@ -1,0 +1,121 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+
+import Changeset from 'ember-changeset';
+import lookupValidator from 'ember-changeset-validations';
+import { ChangesetDef } from 'ember-changeset/types';
+import Intl from 'ember-intl/services/intl';
+import { layout } from 'ember-osf-web/decorators/component';
+import NodeModel from 'ember-osf-web/models/node';
+import { buildValidation, SchemaBlock, SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema';
+import DraftRegistrationManager from 'registries/drafts/draft/draft-registration-manager';
+
+import styles from './styles';
+import template from './template';
+
+@layout(template, styles)
+@tagName('')
+export default class ArrayInput extends Component {
+    // Required param
+    changeset!: ChangesetDef;
+    metadataChangeset!: ChangesetDef;
+    draftManager!: DraftRegistrationManager;
+    @service intl!: Intl;
+
+    @alias('schemaBlock.registrationResponseKey')
+    valuePath!: string;
+    onInput!: () => void;
+    onMetadataInput!: () => void;
+    schemaBlockGroup!: SchemaBlockGroup;
+    schemaBlock!: SchemaBlock;
+    node!: NodeModel;
+
+    subChangesets: ChangesetDef[] = [];
+
+    didReceiveAttrs() {
+        const rowAdditionCaption = this.schemaBlock.rowAdditionCaption || '';
+
+        this.schemaBlock.rowAdditionCaption = this.getLocalizedText(rowAdditionCaption);
+
+        const raw = this.changeset.get(this.valuePath);
+        if (raw) {
+            const prefix = `${this.valuePath}|`;
+            const values = JSON.parse(raw);
+            const subChangesets: ChangesetDef[] = values.map((row: Array<{key: string, value: any}>) => {
+                const subChangeset = this.createSubChangeset();
+                Object.entries(row).forEach(([k, v]) => {
+                    const key2 = `${prefix}${k}`;
+                    subChangeset.set(key2, v);
+                });
+                subChangeset.on('afterValidation', () => {
+                    this.save(this.get('subChangesets'));
+                });
+                return subChangeset;
+            });
+            this.set('subChangesets', subChangesets);
+        } else {
+            this.set('subChangesets', []);
+        }
+    }
+
+    save(subChangesets: ChangesetDef[]) {
+        const prefix = `${this.valuePath}|`;
+        const allChanges = subChangesets.map(changeset => {
+            const changes: Array<{key: string, value: any}> = changeset.changes as any;
+            const row: {[key: string]: any} = {};
+            changes.forEach(({ key, value }) => {
+                assert(
+                    `Sub changeset key ${key} requires starting with parent key ${prefix}`,
+                    key.startsWith(prefix),
+                );
+                const key2 = key.substr(prefix.length);
+                row[key2] = value;
+            });
+            return row;
+        }).filter(changes => Object.keys(changes).length);
+        // todo: exclude rows where all values are empty
+        this.changeset.set(this.valuePath, JSON.stringify(allChanges));
+    }
+
+    createSubChangeset() {
+        const validations = buildValidation(this.schemaBlockGroup.children!, this.node);
+        const subChangeset = new Changeset(
+            {},
+            lookupValidator(validations),
+            validations,
+        ) as ChangesetDef;
+        // todo: setupEventForSyncValidation
+        return subChangeset;
+    }
+
+    @action
+    onAdd() {
+        const subChangeset = this.createSubChangeset();
+        this.set('subChangesets', [...this.get('subChangesets'), subChangeset]);
+        subChangeset.on('afterValidation', () => {
+            this.save(this.get('subChangesets'));
+        });
+    }
+
+    @action
+    onRemove(subChangeset: ChangesetDef) {
+        const newSubChangesets = this.get('subChangesets').filter(c => c !== subChangeset);
+        this.set('subChangesets', newSubChangesets);
+        this.save(newSubChangesets);
+    }
+
+    getLocalizedText(text: string) {
+        if (!text.includes('|')) {
+            return text;
+        }
+        const texts = text.split('|');
+        if (this.intl.locale.includes('ja')) {
+            return texts[0];
+        }
+        return texts[1];
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/ad-metadata-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/ad-metadata-input/styles.scss
@@ -1,0 +1,49 @@
+.file-metadata-input-container {
+    width: 100%;
+    border: 1px solid #eee;
+    padding: 0.5em;
+}
+
+.file-metadata-input-files {
+    border: 1px solid #eee;
+}
+
+.file-metadata-input-files th {
+    border: 1px solid #eee;
+    background: #f5f5f5;
+    height: 35px;
+}
+
+.file-metadata-input-files td {
+    border-top: 1px solid #eee;
+    height: 35px;
+}
+
+.file-metadata-input-files .file-metadata-path {
+    max-width: 250px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.file-metadata-input-files .file-metadata-title {
+    max-width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.file-metadata-input-files .file-metadata-manager {
+    max-width: 50px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.file-metadata-input-edit-button {
+    padding: 0 !important;
+}
+
+.file-metadata-input-buttons {
+    margin-bottom: 4px;
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/ad-metadata-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/ad-metadata-input/template.hbs
@@ -1,0 +1,75 @@
+<Registries::SchemaBlockRenderer::Editable::Base @helpText={{this.schemaBlock.helpText}}>
+    {{#if this.fileEntries}}
+        <table class='table table-responsive' local-class='file-metadata-input-files'>
+            <thead>
+                <tr>
+                    <th class='col-md-1'>
+                    </th>
+                    <th class='col-md-3'>
+                        {{t 'metadata.file-metadata-input.columns.path'}}
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {{#each this.fileEntries as |fileEntry|}}
+                    {{#if fileEntry.visible}}
+                        <tr>
+                            <td class='col-md-1'>
+                                {{#if fileEntry.added}}
+                                    <button
+                                      data-test-file-metadata-input-upper
+                                      class='btn btn-link'
+                                      local-class='file-metadata-input-edit-button'
+                                        {{action this.removeFileMetadata fileEntry}}
+                                    >
+                                        <i class='fa fa-check-square'></i>
+                                    </button>
+                                {{else if fileEntry.hasProject}}
+                                    <button
+                                      data-test-file-metadata-input-upper
+                                      class='btn btn-link'
+                                      local-class='file-metadata-input-edit-button'
+                                        {{action this.addFileMetadata fileEntry}}
+                                    >
+                                        <i class='fa fa-square'></i>
+                                    </button>
+                                {{/if}}
+                            </td>
+                            <td class='col-md-4'>
+                                <p style={{fileEntry.style}} local-class='file-metadata-path'>
+                                    {{#if fileEntry.folder}}
+                                        {{#if fileEntry.folderExpanded}}
+                                            <button
+                                              data-test-file-metadata-input-expand-minus
+                                              class='btn btn-link'
+                                              local-class='file-metadata-input-edit-button'
+                                                {{action this.expandFolder fileEntry false}}
+                                            >
+                                                <i class='fa fa-minus'></i>
+                                            </button>
+                                        {{else}}
+                                            <button
+                                              data-test-file-metadata-input-expand-plus
+                                              class='btn btn-link'
+                                              local-class='file-metadata-input-edit-button'
+                                                {{action this.expandFolder fileEntry true}}
+                                            >
+                                                <i class='fa fa-plus'></i>
+                                            </button>
+                                        {{/if}}
+                                        <i class='fa fa-folder'></i>
+                                    {{else}}
+                                        <i class='fa fa-file'></i>
+                                    {{/if}}
+                                    {{fileEntry.lastPart}}
+                                </p>
+                            </td>
+                        </tr>
+                    {{/if}}
+                {{/each}}
+            </tbody>
+        </table>
+    {{else}}
+        <LoadingIndicator @dark={{true}} />
+    {{/if}}
+</Registries::SchemaBlockRenderer::Editable::Base>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/array-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/array-input/component.ts
@@ -4,13 +4,17 @@ import Component from '@ember/component';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+
 import Changeset from 'ember-changeset';
 import lookupValidator from 'ember-changeset-validations';
 import { ChangesetDef } from 'ember-changeset/types';
+import Intl from 'ember-intl/services/intl';
 import { layout } from 'ember-osf-web/decorators/component';
 import NodeModel from 'ember-osf-web/models/node';
-import { buildValidation, SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema';
+import { buildValidation, SchemaBlock, SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema';
 import DraftRegistrationManager from 'registries/drafts/draft/draft-registration-manager';
+
 import styles from './styles';
 import template from './template';
 
@@ -21,17 +25,23 @@ export default class ArrayInput extends Component {
     changeset!: ChangesetDef;
     metadataChangeset!: ChangesetDef;
     draftManager!: DraftRegistrationManager;
+    @service intl!: Intl;
 
     @alias('schemaBlock.registrationResponseKey')
     valuePath!: string;
     onInput!: () => void;
     onMetadataInput!: () => void;
     schemaBlockGroup!: SchemaBlockGroup;
+    schemaBlock!: SchemaBlock;
     node!: NodeModel;
 
     subChangesets: ChangesetDef[] = [];
 
     didReceiveAttrs() {
+        const rowAdditionCaption = this.schemaBlock.rowAdditionCaption || '';
+
+        this.schemaBlock.rowAdditionCaption = this.getLocalizedText(rowAdditionCaption);
+
         const raw = this.changeset.get(this.valuePath);
         if (raw) {
             const prefix = `${this.valuePath}|`;
@@ -97,5 +107,16 @@ export default class ArrayInput extends Component {
         const newSubChangesets = this.get('subChangesets').filter(c => c !== subChangeset);
         this.set('subChangesets', newSubChangesets);
         this.save(newSubChangesets);
+    }
+
+    getLocalizedText(text: string) {
+        if (!text.includes('|')) {
+            return text;
+        }
+        const texts = text.split('|');
+        if (this.intl.locale.includes('ja')) {
+            return texts[0];
+        }
+        return texts[1];
     }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/array-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/array-input/template.hbs
@@ -23,7 +23,7 @@
             <OsfButton local-class='array-input-remove-button'
               @onClick={{action this.onRemove subChangeset}}
             >
-                {{t 'metadata.array-input.remove-item'}}
+                {{this.schemaBlock.rowAdditionCaption}}{{t 'metadata.array-input.remove-item'}}
             </OsfButton>
         </div>
     {{/each}}
@@ -32,7 +32,7 @@
       @type='primary'
       @onClick={{action this.onAdd}}
     >
-        {{t 'metadata.array-input.add-item'}}
+        {{this.schemaBlock.rowAdditionCaption}}{{t 'metadata.array-input.add-item'}}
     </OsfButton>
 
 </Registries::SchemaBlockRenderer::Editable::Base>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-number-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-number-input/component.ts
@@ -54,6 +54,7 @@ export default class ERadAwardNumberInput extends Component {
         if (eradRecord) {
             kadaiId = eradRecord.kadai_id;
             this.updateCode('e-rad-award-funder-input', eradRecord.haibunkikan_cd);
+            this.updateCode('single-select-pulldown-input', eradRecord.haibunkikan_cd);
             this.updateCode('e-rad-award-field-input', eradRecord.bunya_cd);
             this.changeset.set(
                 this.draftManager.getResponseKeyByBlockType('e-rad-award-title-ja-input'),

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-title-en-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-title-en-input/template.hbs
@@ -10,7 +10,6 @@
             local-class='schema-block-input'
             @uniqueID={{@uniqueID}}
             @valuePath={{@schemaBlock.registrationResponseKey}}
-            @onChange={{action this.onInput2}}
             @onKeyUp={{action this.onInput2}}
             @placeholder=' '
         />

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-title-ja-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/e-rad-award-title-ja-input/template.hbs
@@ -10,7 +10,6 @@
             local-class='schema-block-input'
             @uniqueID={{@uniqueID}}
             @valuePath={{@schemaBlock.registrationResponseKey}}
-            @onChange={{action this.onInput2}}
             @onKeyUp={{action this.onInput2}}
             @placeholder=' '
         />

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/japan-grant-number-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/japan-grant-number-input/component.ts
@@ -54,6 +54,7 @@ export default class JapanGrantNumberInput extends Component {
         if (eradRecord) {
             kadaiId = eradRecord.japan_grant_number;
             this.updateCode('e-rad-award-funder-input', eradRecord.haibunkikan_cd);
+            this.updateCode('single-select-pulldown-input', eradRecord.haibunkikan_cd);
             this.updateCode('e-rad-award-field-input', eradRecord.bunya_cd);
             if (eradRecord.funding_stream_code) {
                 const key = this.getResponseKeyByBlockType('funding-stream-code-input');

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/pulldown-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/pulldown-input/component.ts
@@ -1,0 +1,85 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+import { assert } from '@ember/debug';
+import { action, computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+
+import { ChangesetDef } from 'ember-changeset/types';
+import Intl from 'ember-intl/services/intl';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema';
+
+import template from './template';
+
+@layout(template)
+@tagName('')
+export default class PullDownInput extends Component {
+    @service intl!: Intl;
+    // Required param
+    optionBlocks!: SchemaBlock[];
+    changeset!: ChangesetDef;
+
+    @alias('schemaBlock.registrationResponseKey')
+    valuePath!: string;
+    onInput!: () => void;
+    onMetadataInput!: () => void;
+
+    anotherOption?: string;
+
+    didReceiveAttrs() {
+        assert(
+            'SchemaBlockRenderer::Editable::PullDownInput requires optionBlocks to render',
+            Boolean(this.optionBlocks),
+        );
+    }
+
+    @computed('optionBlocks.[]', 'anotherOption')
+    get optionBlockValues() {
+        const options = this.optionBlocks
+            .map(item => this.getLocalizedItemText(item));
+        if (this.anotherOption) {
+            options.push(this.anotherOption);
+        }
+        return options;
+    }
+
+    @action
+    onChange(option: string) {
+        const code = (option || '').trim();
+        const item = this.optionBlocks.find(b => code === b.displayText);
+        const result = item ? item.displayText : option;
+        this.changeset.set(this.valuePath, result);
+        this.onMetadataInput();
+        this.onInput();
+        this.set('anotherOption', null);
+    }
+
+    @action
+    onInputSearch(text: string) {
+        if (!this.optionBlocks.find(item => item.displayText === text || this.getLocalizedItemText(item) === text)) {
+            this.set('anotherOption', text);
+        }
+        return true;
+    }
+
+    getLocalizedItemText(item: SchemaBlock) {
+        const text = item.helpText || item.displayText;
+        if (text === undefined) {
+            return item.displayText;
+        }
+        return `${item.displayText}`;
+    }
+
+    getLocalizedText(text: string) {
+        if (!text.includes('|')) {
+            return text;
+        }
+        const texts = text.split('|');
+        if (this.intl.locale.includes('ja')) {
+            return texts[0];
+        }
+        return texts;
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/pulldown-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/pulldown-input/styles.scss
@@ -1,0 +1,9 @@
+.schema-block-input {
+    :global(input) {
+        height: 40px;
+        background-color: $color-bg-gray-blue-light;
+        color: $color-text-gray-blue;
+        border-radius: 2px;
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/pulldown-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/pulldown-input/template.hbs
@@ -1,0 +1,26 @@
+<Registries::SchemaBlockRenderer::Editable::Base @helpText={{this.schemaBlock.helpText}}>
+    <FormControls
+      @changeset={{@changeset}}
+      @disabled={{@disabled}}
+      @shouldShowMessages={{@shouldShowMessages}}
+      ...attributes
+    >
+        <PowerSelect
+          data-test-e-rad-award-number-input
+          @options={{this.optionBlockValues}}
+          @onchange={{action this.onChange}}
+          @oninput={{action this.onInputSearch}}
+          @searchEnabled={{true}}
+          @selected={{or (get @changeset this.valuePath) null}}
+          @uniqueID={{@uniqueID}}
+          as |option|
+        >
+            {{option}}
+        </PowerSelect>
+        <ValidationErrors
+          local-class='ValidationErrors'
+          @changeset={{@changeset}}
+          @key={{@schemaBlock.registrationResponseKey}}
+        />
+    </FormControls>
+</Registries::SchemaBlockRenderer::Editable::Base>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/single-select-pulldown-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/single-select-pulldown-input/component.ts
@@ -1,0 +1,85 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+import { assert } from '@ember/debug';
+import { action, computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+
+import { ChangesetDef } from 'ember-changeset/types';
+import Intl from 'ember-intl/services/intl';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema';
+
+import template from './template';
+
+@layout(template)
+@tagName('')
+export default class SingleSelectPulldownInput extends Component {
+    @service intl!: Intl;
+    // Required param
+    optionBlocks!: SchemaBlock[];
+    changeset!: ChangesetDef;
+
+    @alias('schemaBlock.registrationResponseKey')
+    valuePath!: string;
+    onInput!: () => void;
+    onMetadataInput!: () => void;
+
+    anotherOption?: string;
+
+    didReceiveAttrs() {
+        assert(
+            'SchemaBlockRenderer::Editable::SingleSelectPulldownInput requires optionBlocks to render',
+            Boolean(this.optionBlocks),
+        );
+    }
+
+    @computed('optionBlocks.[]', 'anotherOption')
+    get optionBlockValues() {
+        const options = this.optionBlocks
+            .map(item => this.getLocalizedItemText(item));
+        if (this.anotherOption) {
+            options.push(this.anotherOption);
+        }
+        return options;
+    }
+
+    @action
+    onChange(option: string) {
+        const code = (option || '').trim();
+        const item = this.optionBlocks.find(b => code === b.displayText);
+        const result = item ? item.displayText : option;
+        this.changeset.set(this.valuePath, result);
+        this.onMetadataInput();
+        this.onInput();
+        this.set('anotherOption', null);
+    }
+
+    @action
+    onInputSearch(text: string) {
+        if (!this.optionBlocks.find(item => item.displayText === text || this.getLocalizedItemText(item) === text)) {
+            this.set('anotherOption', text);
+        }
+        return true;
+    }
+
+    getLocalizedItemText(item: SchemaBlock) {
+        const text = item.helpText || item.displayText;
+        if (text === undefined) {
+            return item.displayText;
+        }
+        return `${item.displayText}`;
+    }
+
+    getLocalizedText(text: string) {
+        if (!text.includes('|')) {
+            return text;
+        }
+        const texts = text.split('|');
+        if (this.intl.locale.includes('ja')) {
+            return texts[0];
+        }
+        return texts[1];
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/single-select-pulldown-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/single-select-pulldown-input/styles.scss
@@ -1,0 +1,9 @@
+.schema-block-input {
+    :global(input) {
+        height: 40px;
+        background-color: $color-bg-gray-blue-light;
+        color: $color-text-gray-blue;
+        border-radius: 2px;
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/single-select-pulldown-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/single-select-pulldown-input/template.hbs
@@ -1,0 +1,26 @@
+<Registries::SchemaBlockRenderer::Editable::Base @helpText={{this.schemaBlock.helpText}}>
+    <FormControls
+      @changeset={{@changeset}}
+      @disabled={{@disabled}}
+      @shouldShowMessages={{@shouldShowMessages}}
+      ...attributes
+    >
+        <PowerSelect
+          data-test-e-rad-award-number-input
+          @options={{this.optionBlockValues}}
+          @onchange={{action this.onChange}}
+          @oninput={{action this.onInputSearch}}
+          @searchEnabled={{true}}
+          @selected={{or (get @changeset this.valuePath) null}}
+          @uniqueID={{@uniqueID}}
+          as |option|
+        >
+            {{option}}
+        </PowerSelect>
+        <ValidationErrors
+          local-class='ValidationErrors'
+          @changeset={{@changeset}}
+          @key={{@schemaBlock.registrationResponseKey}}
+        />
+    </FormControls>
+</Registries::SchemaBlockRenderer::Editable::Base>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/singleselect-pulldown-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/singleselect-pulldown-input/component.ts
@@ -1,0 +1,85 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+import { assert } from '@ember/debug';
+import { action, computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+
+import { ChangesetDef } from 'ember-changeset/types';
+import Intl from 'ember-intl/services/intl';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema';
+
+import template from './template';
+
+@layout(template)
+@tagName('')
+export default class SingleSelectPulldownInput extends Component {
+    @service intl!: Intl;
+    // Required param
+    optionBlocks!: SchemaBlock[];
+    changeset!: ChangesetDef;
+
+    @alias('schemaBlock.registrationResponseKey')
+    valuePath!: string;
+    onInput!: () => void;
+    onMetadataInput!: () => void;
+
+    anotherOption?: string;
+
+    didReceiveAttrs() {
+        assert(
+            'SchemaBlockRenderer::Editable::SingleSelectPulldownInput requires optionBlocks to render',
+            Boolean(this.optionBlocks),
+        );
+    }
+
+    @computed('optionBlocks.[]', 'anotherOption')
+    get optionBlockValues() {
+        const options = this.optionBlocks
+            .map(item => this.getLocalizedItemText(item));
+        if (this.anotherOption) {
+            options.push(this.anotherOption);
+        }
+        return options;
+    }
+
+    @action
+    onChange(option: string) {
+        const code = (option || '').trim();
+        const item = this.optionBlocks.find(b => code === b.displayText);
+        const result = item ? item.displayText : option;
+        this.changeset.set(this.valuePath, result);
+        this.onMetadataInput();
+        this.onInput();
+        this.set('anotherOption', null);
+    }
+
+    @action
+    onInputSearch(text: string) {
+        if (!this.optionBlocks.find(item => item.displayText === text || this.getLocalizedItemText(item) === text)) {
+            this.set('anotherOption', text);
+        }
+        return true;
+    }
+
+    getLocalizedItemText(item: SchemaBlock) {
+        const text = item.helpText || item.displayText;
+        if (text === undefined) {
+            return item.displayText;
+        }
+        return `${item.displayText}`;
+    }
+
+    getLocalizedText(text: string) {
+        if (!text.includes('|')) {
+            return text;
+        }
+        const texts = text.split('|');
+        if (this.intl.locale.includes('ja')) {
+            return texts[0];
+        }
+        return texts[1];
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/singleselect-pulldown-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/singleselect-pulldown-input/styles.scss
@@ -1,0 +1,9 @@
+.schema-block-input {
+    :global(input) {
+        height: 40px;
+        background-color: $color-bg-gray-blue-light;
+        color: $color-text-gray-blue;
+        border-radius: 2px;
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/singleselect-pulldown-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/singleselect-pulldown-input/template.hbs
@@ -1,0 +1,26 @@
+<Registries::SchemaBlockRenderer::Editable::Base @helpText={{this.schemaBlock.helpText}}>
+    <FormControls
+      @changeset={{@changeset}}
+      @disabled={{@disabled}}
+      @shouldShowMessages={{@shouldShowMessages}}
+      ...attributes
+    >
+        <PowerSelect
+          data-test-e-rad-award-number-input
+          @options={{this.optionBlockValues}}
+          @onchange={{action this.onChange}}
+          @oninput={{action this.onInputSearch}}
+          @searchEnabled={{true}}
+          @selected={{or (get @changeset this.valuePath) null}}
+          @uniqueID={{@uniqueID}}
+          as |option|
+        >
+            {{option}}
+        </PowerSelect>
+        <ValidationErrors
+          local-class='ValidationErrors'
+          @changeset={{@changeset}}
+          @key={{@schemaBlock.registrationResponseKey}}
+        />
+    </FormControls>
+</Registries::SchemaBlockRenderer::Editable::Base>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/text/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/text/template.hbs
@@ -11,6 +11,14 @@
             @uniqueID={{@uniqueID}}
             @valuePath={{@schemaBlock.registrationResponseKey}}
             @onKeyUp={{@onInput}}
+            @retrievalTitle={{@schemaBlock.retrievalTitle}}
+            @retrievalDate={{@schemaBlock.retrievalDate}}
+            @retrievalVersion={{@schemaBlock.retrievalVersion}}
+            @readonly={{@schemaBlock.readonly}}
+            @title={{@draftManager.node.title}}
+            @nodeId={{@node.id}}
+            @datetimeInitiated={{@draftManager.draftRegistration.datetimeInitiated}}
+            @datetimeUpdated={{@draftManager.draftRegistration.datetimeUpdated}}
             @placeholder=' '
         />
     </FormControls>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/component.ts
@@ -49,6 +49,25 @@ export default class LabelContent extends Component {
         return this.getLocalizedText(text);
     }
 
+    @computed('localizedHelpText')
+    get localizedHelpTextLines() {
+        const text = this.localizedHelpText;
+        if (!text) {
+            return [];
+        }
+
+        return text.split('\n').map(line => {
+            const urlRegex = /(https?:\/\/[^\s]+)/g;
+
+            const parts = line.split(urlRegex).map(part => ({
+                content: part,
+                isLink: part.startsWith('https://'),
+            }));
+
+            return parts;
+        });
+    }
+
     getLocalizedText(text: string) {
         if (!text.includes('|')) {
             return text;

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
@@ -1,7 +1,6 @@
 .DisplayText {
     white-space: pre-wrap;
     display: inline-block;
-    margin: 0;
 }
 
 .Required {
@@ -13,8 +12,8 @@
 .HelpText {
     composes: Element from '../../styles';
 
-    white-space: pre-wrap;
     font-weight: 400;
+    margin-top: 0;
 }
 
 .ExampleButton {
@@ -36,4 +35,10 @@
 
     white-space: pre-wrap;
     font-weight: 400;
+}
+
+
+.HelpTextLine {
+    font-weight: normal !important;
+    margin-bottom: 0;
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
@@ -8,9 +8,26 @@
     {{~/if~}}
 </p>
 {{#if @isEditableForm}}
-    <p local-class='HelpText'>
-        {{~this.localizedHelpText~}}
-    </p>
+    <div local-class='HelpText'>
+        {{#each this.localizedHelpTextLines as |lineParts|}}
+            <p local-class='HelpTextLine'>
+                {{#each lineParts as |part|}}
+                    {{#if part.isLink}}
+                        <a
+                            href={{part.content}}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                        >
+                            {{part.content}}
+                        </a>
+                    {{else}}
+                        {{part.content}}
+                    {{/if}}
+                {{/each}}
+            </p>
+        {{/each}}
+    </div>
+
     {{#if @schemaBlock.exampleText}}
         <OsfButton
             local-class='ExampleButton'

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/page-heading/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/page-heading/component.ts
@@ -29,9 +29,23 @@ export default class PageHeading extends Component {
     get localizedHelpText() {
         const text = this.schemaBlock.helpText;
         if (!text) {
-            return text;
+            return [];
         }
-        return this.getLocalizedText(text);
+
+        const localizedText = this.getLocalizedText(text);
+
+        const urlPattern = /(https?:\/\/[^\s]+)/g;
+
+        const lines = localizedText.split('\n').map(line => {
+            const parts = line.split(urlPattern).map(part => (
+                urlPattern.test(part)
+                    ? { type: 'link', content: part.trim() }
+                    : { type: 'text', content: part.trim() }
+            ));
+            return parts;
+        });
+
+        return lines;
     }
 
     getLocalizedText(text: string) {

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/page-heading/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/page-heading/styles.scss
@@ -5,5 +5,5 @@
 }
 
 .PageHeading_helper {
-    margin-top: 10px;
+    margin-bottom: 0;
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/page-heading/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/page-heading/template.hbs
@@ -1,11 +1,31 @@
-<h2
-    local-class='PageHeading'
-    data-test-page-heading
-    id={{@schemaBlock.elementId}}
-    ...attributes
->
-    {{this.localizedDisplayText}}
-</h2>
+{{#if (or (not @schemaBlock.concealmentPageNavigator) (eq @schemaBlock.concealmentPageNavigator undefined)) }}
+    <h2
+        local-class='PageHeading'
+        data-test-page-heading
+        id={{@schemaBlock.elementId}}
+        ...attributes
+    >
+        {{this.localizedDisplayText}}
+    </h2>
+{{/if}}
 {{#if this.isEditableForm}}
-    <p local-class='PageHeading_helper'>{{this.localizedHelpText}}</p>
+    <div local-class='PageHeading_helper'>
+        {{#each this.localizedHelpText as |line|}}
+            <p local-class='PageHeading_helper'>
+                {{#each line as |part|}}
+                    {{#if (eq part.type 'link')}}
+                        <a
+                            href={{part.content}}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                        >
+                            {{part.content}}
+                        </a>
+                    {{else}}
+                        {{part.content}}
+                    {{/if}}
+                {{/each}}
+            </p>
+        {{/each}}
+    </div>
 {{/if}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
@@ -27,6 +27,12 @@
         registrationResponses=@registrationResponses
         changeset=@changeset
     )
+    date-input=(
+        component
+        'registries/schema-block-renderer/read-only/response'
+        registrationResponses=@registrationResponses
+        changeset=@changeset
+    )
     long-text-input=(
         component
         'registries/schema-block-renderer/read-only/response'
@@ -86,6 +92,12 @@
         registrationResponses=@registrationResponses
         changeset=@changeset
     )
+    pulldown-input=(
+        component
+        'registries/schema-block-renderer/read-only/response'
+        registrationResponses=@registrationResponses
+        changeset=@changeset
+    )
     e-rad-award-number-input=(
         component
         'registries/schema-block-renderer/read-only/response'
@@ -113,6 +125,13 @@
     file-metadata-input=(
         component
         'registries/schema-block-renderer/read-only/rdm/file-metadata-input'
+        registrationResponses=@registrationResponses
+        changeset=@changeset
+        node=@node
+    )
+    ad-metadata-input=(
+        component
+        'registries/schema-block-renderer/read-only/rdm/ad-metadata-input'
         registrationResponses=@registrationResponses
         changeset=@changeset
         node=@node

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/ad-metadata-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/ad-metadata-input/component.ts
@@ -1,0 +1,79 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+import { assert } from '@ember/debug';
+
+import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+import { ChangesetDef } from 'ember-changeset/types';
+import Intl from 'ember-intl/services/intl';
+import { layout } from 'ember-osf-web/decorators/component';
+import NodeModel from 'ember-osf-web/models/node';
+import styles from './styles';
+import template from './template';
+
+interface FileMetadataEntity {
+    comments?: any[];
+    extra?: any[];
+    value: any;
+}
+
+interface FileMetadata {
+    path: string;
+    urlpath: string | null;
+    metadata: {
+        [key: string]: FileMetadataEntity,
+    };
+}
+
+interface FileEntry {
+    path: string;
+}
+
+@layout(template, styles)
+@tagName('')
+export default class AdMetadataInput extends Component {
+    @service intl!: Intl;
+
+    // Required param
+    changeset!: ChangesetDef;
+    node!: NodeModel;
+
+    @alias('schemaBlock.registrationResponseKey')
+    valuePath!: string;
+    onInput!: () => void;
+
+    didReceiveAttrs() {
+        assert(
+            'Registries::SchemaBlockRenderer::Editable::Rdm::AdMetadataInput requires a changeset to render',
+            Boolean(this.changeset),
+        );
+        assert(
+            'Registries::SchemaBlockRenderer::Editable::Rdm::AdMetadataInput requires a node to render',
+            Boolean(this.node),
+        );
+        assert(
+            'Registries::SchemaBlockRenderer::Editable::Rdm::AdMetadataInput requires a valuePath to render',
+            Boolean(this.valuePath),
+        );
+    }
+
+    @computed('changeset', 'valuePath')
+    get adMetadatas(): FileMetadata[] {
+        if (!this.changeset) {
+            return [];
+        }
+        const value = this.changeset.get(this.valuePath);
+        if (!value) {
+            return [];
+        }
+        return JSON.parse(value) as FileMetadata[];
+    }
+
+    @computed('adMetadatas')
+    get fileEntries(): FileEntry[] {
+        return this.get('adMetadatas').map(metadata => ({
+            path: metadata.path,
+        }) as FileEntry);
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/ad-metadata-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/ad-metadata-input/styles.scss
@@ -1,0 +1,49 @@
+.file-metadata-input-container {
+    width: 100%;
+    border: 1px solid #eee;
+    padding: 0.5em;
+}
+
+.file-metadata-input-files {
+    border: 1px solid #eee;
+}
+
+.file-metadata-input-files th {
+    border: 1px solid #eee;
+    background: #f5f5f5;
+    height: 35px;
+}
+
+.file-metadata-input-files td {
+    border-top: 1px solid #eee;
+    height: 35px;
+}
+
+.file-metadata-input-files .file-metadata-path {
+    max-width: 250px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.file-metadata-input-files .file-metadata-title {
+    max-width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.file-metadata-input-files .file-metadata-manager {
+    max-width: 50px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.file-metadata-input-edit-button {
+    padding: 0 !important;
+}
+
+.file-metadata-input-buttons {
+    margin-bottom: 4px;
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/ad-metadata-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/rdm/ad-metadata-input/template.hbs
@@ -1,0 +1,24 @@
+<Registries::SchemaBlockRenderer::Editable::Base @helpText={{this.schemaBlock.helpText}}>
+    {{#if this.fileEntries }}
+        <table class='table table-responsive' local-class='file-metadata-input-files'>
+            <thead>
+                <tr>
+                    <th class='col-md-12'>
+                        {{t 'metadata.file-metadata-input.columns.path'}}
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {{#each this.fileEntries as |fileEntry|}}
+                    <tr>
+                        <td class='col-md-12'>
+                            {{fileEntry.path}}
+                        </td>
+                    </tr>
+                {{/each}}
+            </tbody>
+        </table>
+    {{else}}
+        <LoadingIndicator @dark={{true}} />
+    {{/if}}
+</Registries::SchemaBlockRenderer::Editable::Base>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/section-heading/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/section-heading/styles.scss
@@ -3,3 +3,19 @@
 
     color: $color-text-gray-blue;
 }
+
+.HelpText {
+    composes: Element from '../styles';
+
+    // white-space: pre-wrap;
+    font-weight: 400;
+    margin-top: 0;
+}
+
+
+.HelpTextLine {
+    font-weight: normal !important;
+    margin-bottom: 0;
+    font-size: 14px;
+    margin-top: 17px;
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/section-heading/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/section-heading/template.hbs
@@ -4,6 +4,9 @@
     ...attributes
 >
     {{this.localizedDisplayText}}
+    <div local-class='HelpText'>
+        <p local-class='HelpTextLine'>{{this.schemaBlock.helpText}}</p>
+    </div>
     <span>
         {{#if this.isEditableForm}}
             <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{this.localizedHelpText}} />

--- a/lib/osf-components/addon/components/validated-input/date/component.ts
+++ b/lib/osf-components/addon/components/validated-input/date/component.ts
@@ -9,7 +9,20 @@ import template from './template';
 @layout(template)
 export default class ValidatedDatePicker<M extends DS.Model> extends BaseValidatedComponent<M> {
     @action
-    onChange(newValue: Date[]) {
-        this.set('value', newValue[0]);
+    onChange(newValue: Date) {
+        this.set(
+            'value',
+            `${newValue.getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, '0')}-${String(new
+            Date().getDate()).padStart(2, '0')}`,
+        );
+    }
+
+    @action
+    getDate() {
+        this.set(
+            'value',
+            `${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, '0')}-${String(new
+            Date().getDate()).padStart(2, '0')}`,
+        );
     }
 }

--- a/lib/osf-components/addon/components/validated-input/date/template.hbs
+++ b/lib/osf-components/addon/components/validated-input/date/template.hbs
@@ -16,5 +16,14 @@
         @minDate={{@minDate}}
         @maxDate={{@maxDate}}
         @disabled={{@disabled}}
-    />
+        @value={{this.value}}
+    />   
+    {{#if @autoValue}} 
+        <OsfButton
+            @type='success'
+            @onClick={{action this.getDate}}
+        >
+            {{t 'registries.drafts.draft.form.auto_button_label'}}
+        </OsfButton>
+    {{/if}}
 {{/validated-input/x-input-wrapper}}

--- a/lib/osf-components/addon/components/validated-input/text/component.ts
+++ b/lib/osf-components/addon/components/validated-input/text/component.ts
@@ -1,8 +1,8 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import DS, { AttributesFor } from 'ember-data';
-
 import { layout } from 'ember-osf-web/decorators/component';
 import defaultTo from 'ember-osf-web/utils/default-to';
-
 import BaseValidatedComponent from '../base-component';
 import template from './template';
 
@@ -10,8 +10,76 @@ import template from './template';
 export default class ValidatedText<M extends DS.Model> extends BaseValidatedComponent<M> {
     valuePath!: AttributesFor<M>;
 
+    @service store!: DS.Store;
+
     // Additional arguments
     password: boolean = defaultTo(this.password, false);
     onKeyUp?: () => void; // Action
-    onChange?: () => void; // Action
+
+    title?: string = this.title;
+    retrievalTitle: string = defaultTo(this.retrievalTitle, '');
+    retrievalDate: string = defaultTo(this.retrievalDate, '');
+    retrievalVersion: string = defaultTo(this.retrievalVersion, '');
+
+    datetimeInitiated: Date = defaultTo(this.datetimeInitiated, new Date());
+    datetimeUpdated: Date = defaultTo(this.datetimeUpdated, new Date());
+
+    readonly: boolean = defaultTo(this.readonly, false);
+
+    didInsertElement() {
+        if (this.datetimeUpdated instanceof Date && !isNaN(this.datetimeUpdated.getTime())
+            && this.datetimeInitiated instanceof Date
+            && !isNaN(this.datetimeInitiated.getTime())) {
+            const diffInMs = this.datetimeUpdated.getTime() - this.datetimeInitiated.getTime();
+            const diffInMinutes = diffInMs / 1000 / 60;
+
+            if (
+                (this.retrievalTitle === 'auto_retrieval' || this.retrievalTitle === 'dual_retrieval')
+                && diffInMinutes <= 1
+            ) {
+                this.set('value', this.title);
+            }
+
+            if (
+                (this.retrievalDate === 'auto_retrieval' || this.retrievalDate === 'dual_retrieval')
+                && diffInMinutes <= 1
+            ) {
+                const now = new Date();
+                const year = now.getFullYear();
+                const month = String(now.getMonth() + 1).padStart(2, '0');
+                const date = String(now.getDate()).padStart(2, '0');
+
+                this.set('value', `${year}-${month}-${date}`);
+            }
+        } else {
+            // Invalid date values for datetimeInitiated or datetimeUpdated.
+        }
+
+        this.set('readonly', this.readonly === true);
+
+        if (this.retrievalVersion !== '') {
+            this.set('value', this.retrievalVersion);
+        }
+    }
+
+    @action
+    getTitle() {
+        this.set('value', this.title);
+    }
+
+    @action
+    getDate() {
+        const now = new Date();
+        const year = now.getFullYear();
+        const month = String(now.getMonth() + 1).padStart(2, '0');
+        const date = String(now.getDate()).padStart(2, '0');
+
+        this.set('value', `${year}-${month}-${date}`);
+    }
+
+    @action
+    onChange(event: Event) {
+        const target = event.target as HTMLInputElement;
+        this.set('value', target.value);
+    }
 }

--- a/lib/osf-components/addon/components/validated-input/text/template.hbs
+++ b/lib/osf-components/addon/components/validated-input/text/template.hbs
@@ -1,6 +1,10 @@
 {{#validated-input/x-input-wrapper
     model=this.model
     changeset=this.changeset
+    title=this.title
+    datetimeInitiated=this.datetimeInitiated
+    datetimeUpdated=this.datetimeUpdated
+    nodeId=this.nodeId
     errors=this.errors
     label=this.label
     valuePath=this.valuePath
@@ -16,7 +20,25 @@
         @class='form-control'
         @name={{@valuePath}}
         @keyUp={{@onKeyUp}}
-        @change={{@onChange}}
-        @disabled={{this.disabled}}
+        @change={{action this.onChange}}
+        @disabled={{this.readonly}}
     />
+
+    {{#if (or (eq @retrievalTitle 'button_retrieval') (eq @retrievalTitle 'dual_retrieval'))}}
+        <OsfButton
+            @type='success'
+            @onClick={{action this.getTitle}}
+        >
+            {{t 'registries.drafts.draft.form.get_retrieval_label'}}
+        </OsfButton>
+    {{/if}}
+
+    {{#if  (or (eq @retrievalDate 'button_retrieval') (eq @retrievalDate 'dual_retrieval'))}}
+        <OsfButton
+            @type='success'
+            @onClick={{action this.getDate}}
+        >
+            {{t 'registries.drafts.draft.form.get_retrieval_label'}}
+        </OsfButton>
+    {{/if}}
 {{/validated-input/x-input-wrapper}}

--- a/lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/ad-metadata-input/component.js
+++ b/lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/ad-metadata-input/component.js
@@ -1,0 +1,2 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/editable/rdm/ad-metadata-input/component';

--- a/lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/pulldown-input/component.js
+++ b/lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/pulldown-input/component.js
@@ -1,0 +1,2 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/editable/rdm/pulldown-input/component';

--- a/lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/single-select-pulldown-input/component.js
+++ b/lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/single-select-pulldown-input/component.js
@@ -1,0 +1,2 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/editable/rdm/singleselect-pulldown-input/component';

--- a/lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/singleselect-pulldown-input/component.js
+++ b/lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/singleselect-pulldown-input/component.js
@@ -1,0 +1,2 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/editable/rdm/single-select-pulldown-input/component';

--- a/lib/osf-components/app/components/registries/schema-block-renderer/read-only/rdm/ad-metadata-input/component.js
+++ b/lib/osf-components/app/components/registries/schema-block-renderer/read-only/rdm/ad-metadata-input/component.js
@@ -1,0 +1,2 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/read-only/rdm/ad-metadata-input/component';

--- a/lib/registries/addon/drafts/draft/-components/right-nav/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/right-nav/component.ts
@@ -1,0 +1,93 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import DS from 'ember-data';
+import Intl from 'ember-intl/services/intl';
+import { layout } from 'ember-osf-web/decorators/component';
+import DraftRegistration from 'ember-osf-web/models/draft-registration';
+import Toast from 'ember-toastr/services/toast';
+import template from './template';
+
+@tagName('')
+@layout(template)
+export default class RightNav extends Component {
+    @service store!: DS.Store;
+    draftRegistrations: DraftRegistration[] = [];
+    @service toast!: Toast;
+
+    @service router!: any;
+    disableButtons: boolean = false;
+    @service intl!: Intl;
+
+    constructor(...args: any[]) {
+        super(...args);
+        this.handleRouteChange();
+        this.router.on('routeDidChange', this.handleRouteChange);
+    }
+
+    willDestroy() {
+        super.willDestroy();
+        this.router.off('routeDidChange', this.handleRouteChange);
+    }
+
+    @action
+    async handleRouteChange() {
+        const currentUrl = window.location.href;
+        const urlParts = currentUrl.split('/');
+        const lastPartWithQuery = urlParts[urlParts.length - 1];
+        const metadataTitle = lastPartWithQuery.split('?')[0];
+        const cleanedTitle = metadataTitle.replace(/^\d+-/, '');
+        const title = decodeURIComponent(cleanedTitle.replace(/-/g, ' '));
+        const allSchemas = await this.store.findAll('registration-schema');
+
+        const matchedSchema = allSchemas.find(
+            (schema: any) => schema.schema.pages.some(
+                (page: any) => page.title.trim().toLowerCase() === title.trim().toLowerCase()
+                    && page.clipboardCopyPaste === false,
+            ),
+        );
+
+        if (!this.isDestroyed && !this.isDestroying) {
+            this.set('disableButtons', !!matchedSchema);
+        }
+    }
+
+    @action
+    async pasteFromClipboard() {
+        try {
+            const clipboardText = await navigator.clipboard.readText();
+            try {
+                const parsedJson = JSON.parse(clipboardText);
+                const structuredJson: {[key: string]: any } = {};
+                Object.entries(parsedJson).forEach(([key, value]) => {
+                    structuredJson[key] = {
+                        extra: [],
+                        value,
+                        comments: [],
+                    };
+                });
+
+                const currentUrl = window.location.href;
+                const idRegex = /\/drafts\/([a-f0-9]{24})/;
+                const match = currentUrl.match(idRegex);
+                if (match && match[1]) {
+                    try {
+                        const draftId = match[1];
+                        const draftRegistration = await this.store.findRecord('draft-registration', draftId);
+                        draftRegistration.set('registrationMetadata', structuredJson);
+                        await draftRegistration.save();
+                        window.location.reload();
+                        this.toast.success(this.intl.t('registries.drafts.draft.form.clipboard_pasted'));
+                    } catch (error) {
+                        this.toast.success(this.intl.t('registries.drafts.draft.form.json_invalid'), error);
+                    }
+                }
+            } catch (error) {
+                this.toast.success(this.intl.t('registries.drafts.draft.form.clipboard_unread'), error);
+            }
+        } catch (error) {
+            this.toast.error('Failed to read from clipboard: ', error);
+        }
+    }
+}

--- a/lib/registries/addon/drafts/draft/-components/right-nav/styles.scss
+++ b/lib/registries/addon/drafts/draft/-components/right-nav/styles.scss
@@ -1,0 +1,11 @@
+.Label {
+    float: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: normal;
+    word-wrap: break-word;
+
+    &:hover {
+        overflow: visible;
+    }
+}

--- a/lib/registries/addon/drafts/draft/-components/right-nav/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/right-nav/template.hbs
@@ -61,3 +61,14 @@
         @date={{@draftManager.draftRegistration.datetimeUpdated}}
     />
 </span>
+
+<OsfButton
+    data-test-paste-from-clipboard
+    data-analytics-name='Paste from clipboard'
+    @onClick={{action this.pasteFromClipboard}}
+    @type='info'
+    @disabled={{this.disableButtons}}
+    local-class='Label'
+>
+    {{t 'registries.drafts.draft.form.from_clipboard_paste'}}
+</OsfButton>

--- a/lib/registries/addon/drafts/draft/styles.scss
+++ b/lib/registries/addon/drafts/draft/styles.scss
@@ -130,3 +130,15 @@
         display: flex;
     }
 }
+
+.BreadCrumb-container {
+    display: flex;
+}
+
+.BreadCrumb-container span {
+    margin-right: 5px;
+}
+
+.MetadataTitleName {
+    color: $white;
+}

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -11,14 +11,18 @@
         <OsfLayout @backgroundClass={{local-class 'ContentBackground'}} as |layout|>
             <layout.heading local-class='Heading'>
                 <div local-class='Title'>
-                    <OsfLink
-                        data-analytics-name='Go to project'
-                        local-class='BreadCrumb'
-                        @route='guid-node'
-                        @models={{array draftManager.node.id}}
-                    >
-                        {{draftManager.node.title}} >
-                    </OsfLink>
+                    <div class='BreadCrumb-container'>
+                        <OsfLink
+                            data-analytics-name='Go to project'
+                            local-class='BreadCrumb'
+                            @route='guid-node'
+                            @models={{array draftManager.node.id}}
+                            style='color: white;'
+                        >
+                            {{draftManager.node.title}} >
+                        </OsfLink>
+                        <span local-class='MetadataTitleName'>{{t 'registries.drafts.draft.form.new_registration'}}></span>
+                    </div>
                     <h1>
                         {{t 'registries.drafts.draft.form.new_registration'}}
                     </h1>
@@ -34,15 +38,19 @@
             {{/if}}
             <layout.leftNav as |leftNav|>
                 {{#each draftManager.pageManagers as |pageManager index|}}
-                    <PageLink
-                        @link={{component leftNav.link}}
-                        @draftId={{draftManager.draftId}}
-                        @pageManager={{pageManager}}
-                        @route='registries.drafts.draft.page'
-                        @pageIndex={{index}}
-                        @currentPageIndex={{navManager.currentPage}}
-                        @navMode={{leftNav.leftGutterMode}}
-                    />
+                    {{#let (get pageManager.schemaBlockGroups 0) as |group|}}
+                        {{#unless group.labelBlock.concealmentPageNavigator}}
+                            <PageLink
+                                @link={{component leftNav.link}}
+                                @draftId={{draftManager.draftId}}
+                                @pageManager={{pageManager}}
+                                @route='registries.drafts.draft.page'
+                                @pageIndex={{index}}
+                                @currentPageIndex={{navManager.currentPage}}
+                                @navMode={{leftNav.leftGutterMode}}
+                            />
+                        {{/unless}}
+                    {{/let}}
                 {{/each}}
                 <PageLink
                     @link={{component leftNav.link}}

--- a/mirage/fixture-data/registration-schemas/prereg-challenge.ts
+++ b/mirage/fixture-data/registration-schemas/prereg-challenge.ts
@@ -428,6 +428,7 @@ export default {
             {
                 type: 'object',
                 id: 'page7',
+                clipboardCopyPaste: false,
                 questions: [
                     {
                         help: '',

--- a/osf/models/component.js
+++ b/osf/models/component.js
@@ -1,0 +1,2 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/read-only/rdm/ad-metadata-input/component';

--- a/tests/integration/components/registries-side-nav/component-test.ts
+++ b/tests/integration/components/registries-side-nav/component-test.ts
@@ -21,6 +21,9 @@ class RouterStub extends Service {
 }
 
 class CurrentUserStub extends Service {
+    ajaxHeaders() {
+        return {};
+    }
 }
 
 /* tslint:disable:only-arrow-functions */

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1025,6 +1025,15 @@ registries:
                 last_saved: 'Auto-saved: '
                 save_failed: 'Save failed. Unsaved changes present.'
                 failed_auto_save: 'Failed to auto-save draft registration form'
+                get_retrieval_label: 'Fill'
+                copy_to_clipboard: 'Copy To Clipboard'
+                from_clipboard_paste: 'From Clipboard Paste'
+                clipboard_copied: 'Clipboard copied!'
+                warning_noautosave: 'Not autosaved. Please try again later!'
+                clipboard_pasted: 'Clipboard pasted!'
+                clipboard_fail: 'Failed to save from clipboard: '
+                json_invalid: 'Clipboard does not contain valid JSON: '
+                clipboard_unread: 'Failed to read from clipboard: '
             review:
                 title: 'Review registration before submitting'
                 page_label: Review

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -1025,6 +1025,15 @@ registries:
                 last_saved: '自動保存済み: '
                 save_failed: '保存に失敗しました。保存できていない変更があります。'
                 failed_auto_save: '下書きの自動保存に失敗しました。'
+                get_retrieval_label: '自動取得'
+                copy_to_clipboard: 'クリップボードにコピー'
+                from_clipboard_paste: 'クリップボードから貼り付け'
+                clipboard_copied: 'クリップボードコピーされました！'
+                warning_noautosave: '自動保存されていません。少し時間をたってから、もう一度お試しください！'
+                clipboard_pasted: 'クリップボード貼り付けされました！'
+                clipboard_fail: 'クリップボードからの保存に失敗しました: '
+                json_invalid: 'クリップボードには有効な JSON が含まれていません: '
+                clipboard_unread: 'クリップボードからの読み取りに失敗しました: '
             review:
                 title: 送信前に登録を確認する
                 page_label: 内容確認


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: []
- Feature flag: n/a

## Purpose

<!-- Describe the purpose of your changes. -->
未病データベースのカタログ登録機能を追加（develop）
デプロイ対象環境：develop（ステージング環境）
デプロイ希望日：即日でお願いいたします。

#583とセットでお願いいたします
https://github.com/RCOSDP/RDM-osf.io/pull/583

## Summary of Changes

<!-- Briefly describe or list your changes. -->
(1) プロジェクト名／日付の自動取得
../app/models/schema-block.ts
../app/packages/registration-schema/schema-block.ts
../lib/osf-components/addon/components/form-controls/template.hbs
../lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
../lib/osf-components/addon/components/registries/schema-block-renderer/editable/text/template.hbs
../lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
../lib/osf-components/addon/components/validated-input/date/component.ts
../lib/osf-components/addon/components/validated-input/date/template.hbs
../lib/osf-components/addon/components/validated-input/text/component.ts
../lib/osf-components/addon/components/validated-input/text/template.hbs
../translations/en-us.yml
../translations/ja.yml

(2) required_if機能の拡張（値の指定を可能する）
../app/models/schema-block.ts
../app/packages/registration-schema/validations.ts
../app/validators/validate-response-format.ts
../translations/en-us.yml
../translations/ja.yml

(3) type:chooseにformat:pulldownを追加
../app/packages/registration-schema/get-schema-block-group.ts
../app/packages/registration-schema/schema-block.ts
../lib/osf-components/addon/components/form-controls/template.hbs
../lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
../lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/japan-grant-number-input/component.ts
../lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/pulldown-input/component.ts
../lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/pulldown-input/styles.scss
../lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/pulldown-input/template.hbs
../lib/osf-components/app/components/registries/schema-block-renderer/editable/rdm/pulldown-input/component.js

(4) メタデータの不要ページ非表示可能とする
../app/packages/registration-schema/get-pages.ts
../app/packages/registration-schema/page-manager.ts
../lib/osf-components/addon/components/registries/schema-block-renderer/page-heading/template.hbs

(5) プロジェクトポータルへのリンクの表示変更
../lib/registries/addon/drafts/draft/styles.scss
../lib/registries/addon/drafts/draft/template.hbs

(6)  カタログ登録前チェックリストのバージョンを自動設定する
　./RDM-ember-osf-web/app/models/schema-block.ts（変更）
　./RDM-ember-osf-web/app/packages/registration-schema/schema-block.ts（変更）
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/editable/text/template.hbs（変更）
　./RDM-ember-osf-web/lib/osf-components/addon/components/validated-input/text/component.ts（変更）
　./RDM-ember-osf-web/lib/osf-components/addon/components/validated-input/text/template.hbs（変更）

(7)  osf-uploadの固定の文書（英文）を非表示にする
　./RDM-ember-osf-web/app/models/schema-block.ts（変更）
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/editable/file/template.hbs（変更）

(8) プロジェクトメタデータのクリップボードコピー
　./RDM-ember-osf-web/lib/osf-components/addon/components/osf-layout/registries-side-nav/component.ts（変更）
　./RDM-ember-osf-web/lib/osf-components/addon/components/osf-layout/registries-side-nav/template.hbs（変更）
　./RDM-ember-osf-web/lib/registries/addon/drafts/draft.-components/right-nav/component.ts（変更）
　./RDM-ember-osf-web/lib/registries/addon/drafts/draft.-components/right-nav/template.hbs（変更）

(9) プロジェクトメタデータのページヘッダーのハイパーリンク
(10) プロジェクトメタデータの項目の注釈の改行とハイパーリンク
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/component.ts
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/page-heading/component.ts
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/page-heading/styles.scss
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/page-heading/template.hbs

(11) A（拡張）メタデータ選択用のファイルツリーを追加する
　./RDM-ember-osf-web/app/packages/registration-schema/get-schema-block-group.ts（変更）
　./RDM-ember-osf-web/app/packages/registration-schema/schema-block.ts（変更）
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs（変更）
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/ad-metadata-input/component.ts（追加）
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/ad-metadata-input/styles.scss（追加）
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/editable/rdm/ad-metadata-input/template.hbs（追加）
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs（変更）
　./RDM-ember-osf-web/lib/osf-components/addon/components/registries/schema-block-renderer/rdm/ad-metadata-input/component.js（追加）
　./RDM-ember-osf-web/osf/models/component.js
　./RDM-osf.io/osf/utils/migrations.py（変更）

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
