### PR TITLE
未病データベース メタデータ登録フォームのエラーメッセージ修正

### DIFF
--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -27,6 +27,7 @@ function getErrorType(groupType?: string) {
         validationErrorType = 'mustSelectFileMinOne';
         break;
     case 'single-select-input':
+    case 'single-select-pulldown-input':
         validationErrorType = 'mustSelect';
         break;
     case 'multi-select-input':

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
@@ -45,6 +45,12 @@
         registrationResponses=@registrationResponses
         changeset=@changeset
     )
+    single-select-pulldown-input=(
+        component
+        'registries/schema-block-renderer/read-only/response'
+        registrationResponses=@registrationResponses
+        changeset=@changeset
+    )
     multi-select-input=(
         component
         'registries/schema-block-renderer/read-only/multi-select'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -542,6 +542,7 @@ validationErrors:
     invalid_format_funder: 'Please use single-byte alphanumeric characters.'
     invalid_format_funding-stream-code: 'Please enter up to 5 single-byte alphanumeric characters.'
     invalid_required_if: 'One of this field or "{otherLabel}" field must be filled.'
+    invalid_required_if_object: 'This field is required based on your previous selection.'
 validated_input_form:
     discard_changes: 'Discard changes'
 node_navbar:

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -533,15 +533,16 @@ validationErrors:
     node_license_invalid: ライセンスの無効な必須項目
     node_license_missing_fields: '次の必須項目がありません。: {missingFields}'
     invalid_doi: 有効なDOI形式(10.xxxx/xxxxx)を使用してください
-    mustSelect: 'You must select a value for this field.'
-    mustSelectMinOne: 'You must select at least one value for this field.'
-    mustSelectFileMinOne: 'You must select at least one file for this field.'
+    mustSelect: このフィールドは値を選択する必要があります。
+    mustSelectMinOne: このフィールドは少なくとも1つの値を選択する必要があります。
+    mustSelectFileMinOne: このフィールドは少なくとも1つのファイルを選択する必要があります。
     onlyProjectOrComponentFiles: 'The {numOfFiles, plural, =1 {file} other {files}} "{missingFilesList}" cannot be found on this {projectOrComponent}.'
     new_folder_name: 'Folder name must not be blank.'
     year_format: 'Please specify a valid year.'
     invalid_format_funder: '半角英数字で入力してください。'
     invalid_format_funding-stream-code: '5文字以内の半角英数字で入力してください。'
     invalid_required_if: 'このフィールドか「{otherLabel}」のいずれかを入力する必要があります。'
+    invalid_required_if_object: このフィールドは他の選択により必須です。
 validated_input_form:
     discard_changes: 変更を破棄
 node_navbar:


### PR DESCRIPTION
## Purpose

未病データベースのメタデータ登録フォームにおける入力チェックのエラーメッセージを修正。

## Summary of Changes

以下の問題を修正。

- 条件付きプルダウン選択項目のエラーメッセージ定義が不足しているため、不適切なエラーメッセージが出力される
- 日本語のエラーメッセージ定義が不足しているため、日本語環境で英語のエラーメッセージが出力される
- プルダウン選択項目で選択した結果が「内容確認」ページで表示されない

## Side Effects

None

## QA Notes

None
