### PR TITLE
解析機能におけるヘルスチェックをOAuthで連携する場合にのみ実施するように修正

### DIFF
--- a/app/guid-node/binderhub/-components/jupyter-servers-list/component.ts
+++ b/app/guid-node/binderhub/-components/jupyter-servers-list/component.ts
@@ -196,12 +196,15 @@ export default class JupyterServersList extends Component {
         return jupyterhub.token.user;
     }
 
-    async updateJHAvailability(jupyterhubUrl: string): Promise<boolean> {
-        const state = await checkJupyterHubAvailability(jupyterhubUrl);
-        if (!state.availability) {
-            this.updateHubsAvailability(state);
+    async updateJHAvailability(jupyterhub: JupyterHub | null): Promise<boolean> {
+        if (jupyterhub && jupyterhub.authorize_url) {
+            const state = await checkJupyterHubAvailability(jupyterhub.url);
+            if (!state.availability) {
+                this.updateHubsAvailability(state);
+            }
+            return state.availability;
         }
-        return state.availability;
+        return true;
     }
 
     /**
@@ -307,18 +310,19 @@ export default class JupyterServersList extends Component {
         this.set('serversLink', null);
         this.set('namedServerLimit', null);
         later(async () => {
-            const availability = await this.updateJHAvailability(jupyterhubUrl);
-            if (availability) {
-                const servers = await this.loadServers(jupyterhubUrl);
-                this.set('serversLink', addPathSegment(jupyterhubUrl, 'hub/home'));
-                if (servers === null) {
-                    this.set('allServers', null);
-                    this.set('namedServerLimit', null);
-                    return;
-                }
-                this.set('allServers', servers.entries);
-                this.set('namedServerLimit', servers.namedServerLimit);
+            const jupyterhub = this.binderHubConfig.findJupyterHubByURL(jupyterhubUrl);
+            if (!(await this.updateJHAvailability(jupyterhub))) {
+                return;
             }
+            const servers = await this.loadServers(jupyterhubUrl);
+            this.set('serversLink', addPathSegment(jupyterhubUrl, 'hub/home'));
+            if (servers === null) {
+                this.set('allServers', null);
+                this.set('namedServerLimit', null);
+                return;
+            }
+            this.set('allServers', servers.entries);
+            this.set('namedServerLimit', servers.namedServerLimit);
         }, 0);
     }
 
@@ -438,8 +442,7 @@ export default class JupyterServersList extends Component {
         const url = new URL(jupyterhub.url);
         url.pathname = server.entry.url;
         later(async () => {
-            const availability = await this.updateJHAvailability(jupyterhub.url);
-            if (availability) {
+            if (await this.updateJHAvailability(jupyterhub)) {
                 window.open(getJupyterHubServerURL(url.toString(), undefined, path), '_blank');
             }
         }, 0);
@@ -454,8 +457,7 @@ export default class JupyterServersList extends Component {
         const url = new URL(jupyterhub.url);
         url.pathname = server.entry.url;
         later(async () => {
-            const availability = await this.updateJHAvailability(url.toString());
-            if (availability) {
+            if (await this.updateJHAvailability(jupyterhub)) {
                 window.open(url.toString(), '_blank');
             }
         }, 0);
@@ -476,22 +478,22 @@ export default class JupyterServersList extends Component {
         const server = this.showDeleteConfirmDialogTarget;
         this.set('showDeleteConfirmDialogTarget', null);
         later(async () => {
-            const availability = await this.updateJHAvailability(server.ownerUrl);
-            if (availability) {
-                const serverpath = server.entry.name.length > 0 ? `servers/${server.entry.name}` : 'server';
-                await this.jupyterhubAPIAJAX(
-                    server.ownerUrl,
-                    `users/${user}/${serverpath}`,
-                    {
-                        method: 'DELETE',
-                        contentType: 'application/json',
-                        data: JSON.stringify({ remove: true }),
-                    },
-                );
-                await this.requestAnnotationDelete(server.entry.url, true);
-                const servers = await this.loadServers(server.ownerUrl);
-                this.set('allServers', servers !== null ? servers.entries : null);
+            if (!(await this.updateJHAvailability(jupyterhub))) {
+                return;
             }
+            const serverpath = server.entry.name.length > 0 ? `servers/${server.entry.name}` : 'server';
+            await this.jupyterhubAPIAJAX(
+                server.ownerUrl,
+                `users/${user}/${serverpath}`,
+                {
+                    method: 'DELETE',
+                    contentType: 'application/json',
+                    data: JSON.stringify({ remove: true }),
+                },
+            );
+            await this.requestAnnotationDelete(server.entry.url, true);
+            const servers = await this.loadServers(server.ownerUrl);
+            this.set('allServers', servers !== null ? servers.entries : null);
         }, 0);
     }
 

--- a/app/guid-node/binderhub/controller.ts
+++ b/app/guid-node/binderhub/controller.ts
@@ -619,12 +619,15 @@ export default class GuidNodeBinderHub extends Controller {
             this.set('selectedHost', { url: hostURL, name: hostURL.toString() });
             this.set('hubsAvailability', true);
             this.removeHubStatusMessage();
-            later(async () => {
-                const state = await checkBinderHubAvailability(hostURLString);
-                if (!state.availability) {
-                    this.updateHubsAvailability(state);
-                }
-            }, 0);
+            const binderhub = this.config.findBinderHubByURL(hostURLString);
+            if (binderhub && binderhub.authorize_url) {
+                later(async () => {
+                    const state = await checkBinderHubAvailability(hostURLString);
+                    if (!state.availability) {
+                        this.updateHubsAvailability(state);
+                    }
+                }, 0);
+            }
             updateContext('bh', hostURL.toString());
         } catch (e) {
             if (e instanceof TypeError) {
@@ -726,7 +729,8 @@ export default class GuidNodeBinderHub extends Controller {
      * safely use `this.model`.
      */
     setup() {
-        const defaultBinderHubURL = new URL(this.config.get('defaultBinderhub').url);
+        const defaultBinderHub = this.config.get('defaultBinderhub');
+        const defaultBinderHubURL = new URL(defaultBinderHub.url);
         this.set(
             'selectedHost',
             this.availableHosts.find(
@@ -737,12 +741,14 @@ export default class GuidNodeBinderHub extends Controller {
             'dyServerAnnotations',
             this.model.serverAnnotations.toArray(),
         );
-        later(async () => {
-            const state = await checkBinderHubAvailability(defaultBinderHubURL.href);
-            if (!state.availability) {
-                this.updateHubsAvailability(state);
-            }
-        }, 0);
+        if (defaultBinderHub.authorize_url) {
+            later(async () => {
+                const state = await checkBinderHubAvailability(defaultBinderHubURL.href);
+                if (!state.availability) {
+                    this.updateHubsAvailability(state);
+                }
+            }, 0);
+        }
     }
 
     @action


### PR DESCRIPTION
- Ticket: 58940
- Feature flag: n/a

## Purpose

解析機能においてTLJHを利用したときに「解析環境を起動する」ボタンが無効化され、解析環境を起動できないバグを修正する。

PR #159  で実装されたBinderHub/JupyterHubのヘルスチェックは、TLJHのように、OAuth2による連携を利用しないHubにおいては不要である。本PRではこのヘルスチェックをOAuth2による認証URL (`authorize_url`) が `null` でない場合にのみ行なうように修正することで、バグを修正する。

## Summary of Changes

BinderHub/JupyterHubのヘルスチェックを、OAuth2による認証URLが `null` でない場合にのみ行なうように修正

## QA Notes

- TLJH E2Eテストにより、TLJHで「解析環境を起動する」ボタンが有効になっていることをテストする
  - RDM-e2e-test-nbのワークフローを、本PRの修正を適用した状態で作ったイメージ `chiku314/rdm-ember-osf-web:hotfix-gate-healthcheck` をCustom Ember Imageとして指定して実行する
  - 実行結果: https://github.com/chiku-samugari/RDM-e2e-test-nb/actions/runs/24331321232/job/71053280840