### PR TITLE
[GRDM-57869] Improve Maintenance Message Display

### DIFF
--- a/app/utils/string-utils.ts
+++ b/app/utils/string-utils.ts
@@ -1,0 +1,49 @@
+export const escapeHTML = (s: string): string => (
+    s.replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+);
+
+export const isEmail = (s: string): boolean => (
+    /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(s)
+);
+
+export const isValidDomain = (host: string): boolean => {
+    if (!/^[a-zA-Z0-9.-]+$/.test(host)) { return false; }
+    if (host.includes('..')) { return false; }
+    if (!host.includes('.')) { return false; }
+
+    const labels = host.split('.');
+    if (labels.some(label => /^-|-$/.test(label) || label === '')) {
+        return false;
+    }
+
+    const tld = labels[labels.length - 1];
+    return /^[a-zA-Z]{2,}$/.test(tld);
+};
+
+export interface TrimEdgesResult {
+    leading: string;
+    core: string;
+    trailing: string;
+}
+
+export const trimEdges = (s: string): TrimEdgesResult => {
+    let core = s;
+    let leading = '';
+    let trailing = '';
+
+    while (/^[([]/.test(core)) {
+        leading += core.charAt(0);
+        core = core.slice(1);
+    }
+
+    while (/[.,!?)\]]$/.test(core)) {
+        trailing = core.slice(-1) + trailing;
+        core = core.slice(0, -1);
+    }
+
+    return { leading, core, trailing };
+};

--- a/app/utils/string-utils.ts
+++ b/app/utils/string-utils.ts
@@ -35,12 +35,12 @@ export const trimEdges = (s: string): TrimEdgesResult => {
     let leading = '';
     let trailing = '';
 
-    while (/^[([]/.test(core)) {
+    while (/^[(<[{【（「『〔]/.test(core)) {
         leading += core.charAt(0);
         core = core.slice(1);
     }
 
-    while (/[.,!?)\]]$/.test(core)) {
+    while (/[.,!?)\]}】）」』〕、。]$/.test(core)) {
         trailing = core.slice(-1) + trailing;
         core = core.slice(0, -1);
     }

--- a/app/utils/string-utils.ts
+++ b/app/utils/string-utils.ts
@@ -6,10 +6,6 @@ export const escapeHTML = (s: string): string => (
         .replace(/'/g, '&#39;')
 );
 
-export const isEmail = (s: string): boolean => (
-    /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(s)
-);
-
 export const isValidDomain = (host: string): boolean => {
     if (!/^[a-zA-Z0-9.-]+$/.test(host)) { return false; }
     if (host.includes('..')) { return false; }

--- a/lib/osf-components/addon/components/maintenance-banner/component.ts
+++ b/lib/osf-components/addon/components/maintenance-banner/component.ts
@@ -12,6 +12,12 @@ import { layout } from 'ember-osf-web/decorators/component';
 import Analytics from 'ember-osf-web/services/analytics';
 import CurrentUser from 'ember-osf-web/services/current-user';
 
+import {
+    escapeHTML,
+    isEmail,
+    isValidDomain,
+    trimEdges,
+} from 'ember-osf-web/utils/string-utils';
 import styles from './styles';
 import template from './template';
 
@@ -75,24 +81,88 @@ export default class MaintenanceBanner extends Component {
             return htmlSafe('');
         }
 
-        const escapeHTML = (str: string) => str
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
+        const parts: string[] = text.split(/(\s+)/);
 
-        const urlRegex = /(https?:\/\/[^\s<>"]+)/g;
-
-        const result = text.split(urlRegex).map(part => {
-            if (part.match(urlRegex)) {
-                const safeUrl = escapeHTML(part);
-                return `<a href="${safeUrl}">${safeUrl}</a>`;
+        const result = parts.map((part: string) => {
+            if (!part) {
+                return '';
             }
-            return escapeHTML(part);
+
+            // preserve whitespace
+            if (/^\s+$/.test(part)) {
+                return part;
+            }
+
+            // split by dangerous characters to support partial parsing
+            const chunks = part.split(/([<>"])/);
+
+            return chunks.map((chunk: string) => {
+                if (!chunk) {
+                    return '';
+                }
+
+                // escape dangerous characters
+                if (/[<>"]/.test(chunk)) {
+                    return escapeHTML(chunk);
+                }
+
+                // extract surrounding punctuation
+                const { leading, core, trailing } = trimEdges(chunk);
+
+                if (isEmail(core)) {
+                    return `${escapeHTML(leading)}<a href="mailto:${escapeHTML(core)}">`
+                        + `${escapeHTML(core)}</a>${escapeHTML(trailing)}`;
+                }
+
+                // scheme:// (loose handling, e.g. htp://)
+                if (/^[a-zA-Z]+:\/\//.test(core)) {
+                    try {
+                        const fake = core.replace(/^([a-zA-Z]+):\/\//, 'http://');
+                        const u = new URL(fake);
+
+                        if (isValidDomain(u.hostname)) {
+                            return `${escapeHTML(leading)}<a href="${escapeHTML(core)}" rel="nofollow">`
+                            + `${escapeHTML(core)}</a>${escapeHTML(trailing)}`;
+                        }
+                    } catch {
+                        // ignore invalid URL parsing
+                    }
+
+                    // fallback: link the prefix part (no strict domain validation)
+                    const match = core.match(/^([a-zA-Z]+:\/\/([a-zA-Z0-9-]+))/);
+                    if (match) {
+                        const full = match[1];
+                        const host = match[2];
+
+                        // reject invalid host patterns
+                        if (!host.startsWith('-') && /^[a-zA-Z0-9-]+$/.test(host)) {
+                            const rest = core.slice(full.length);
+                            return `${escapeHTML(leading)}<a href="${escapeHTML(full)}" rel="nofollow">`
+                            + `${escapeHTML(full)}</a>${escapeHTML(rest + trailing)}`;
+                        }
+                    }
+
+                    return escapeHTML(chunk);
+                }
+
+                // domain (e.g. abc.com, www.google.com)
+                const domainMatch = core.match(/^((?:www\.)?[a-zA-Z0-9-]+\.[a-zA-Z]{2,})(?=$|[^a-zA-Z0-9-])/);
+                if (domainMatch) {
+                    const domain = domainMatch[1];
+                    const host = domain.replace(/^www\./, '');
+
+                    if (isValidDomain(host)) {
+                        const rest = core.slice(domain.length);
+                        return `${escapeHTML(leading)}<a href="http://${escapeHTML(domain)}" rel="nofollow">`
+                        + `${escapeHTML(domain)}</a>${escapeHTML(rest + trailing)}`;
+                    }
+                }
+
+                return escapeHTML(chunk);
+            }).join('');
         }).join('');
-        const withBreaks = result.replace(/\n/g, '<br>');
-        return htmlSafe(withBreaks);
+
+        return htmlSafe(result.replace(/\n/g, '<br>'));
     }
 
     didReceiveAttrs(): void {

--- a/lib/osf-components/addon/components/maintenance-banner/component.ts
+++ b/lib/osf-components/addon/components/maintenance-banner/component.ts
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { htmlSafe } from '@ember/string';
 import { task } from 'ember-concurrency-decorators';
 import Cookies from 'ember-cookies/services/cookies';
 import { localClassNames } from 'ember-css-modules';
@@ -65,6 +66,33 @@ export default class MaintenanceBanner extends Component {
     get alertType(): string | undefined {
         const levelMap = ['info', 'warning', 'danger'];
         return this.maintenance && this.maintenance.level ? levelMap[this.maintenance.level - 1] : undefined;
+    }
+
+    @computed('maintenance.message')
+    get renderedMessage() {
+        const text = this.maintenance && this.maintenance.message ? this.maintenance.message : '';
+        if (!text) {
+            return htmlSafe('');
+        }
+
+        const escapeHTML = (str: string) => str
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+
+        const urlRegex = /(https?:\/\/[^\s<>"]+)/g;
+
+        const result = text.split(urlRegex).map(part => {
+            if (part.match(urlRegex)) {
+                const safeUrl = escapeHTML(part);
+                return `<a href="${safeUrl}">${safeUrl}</a>`;
+            }
+            return escapeHTML(part);
+        }).join('');
+        const withBreaks = result.replace(/\n/g, '<br>');
+        return htmlSafe(withBreaks);
     }
 
     didReceiveAttrs(): void {

--- a/lib/osf-components/addon/components/maintenance-banner/component.ts
+++ b/lib/osf-components/addon/components/maintenance-banner/component.ts
@@ -115,46 +115,60 @@ export default class MaintenanceBanner extends Component {
                 }
 
                 // scheme:// (loose handling, e.g. htp://)
-                if (/^[a-zA-Z]+:\/\//.test(core)) {
+                const schemeIdx = core.search(/[a-zA-Z]+:\/\//);
+                if (schemeIdx >= 0) {
+                    const textBefore = core.slice(0, schemeIdx);
+                    const urlCandidate = core.slice(schemeIdx);
+
                     try {
-                        const fake = core.replace(/^([a-zA-Z]+):\/\//, 'http://');
+                        const fake = urlCandidate.replace(/^([a-zA-Z]+):\/\//, 'http://');
                         const u = new URL(fake);
 
                         if (isValidDomain(u.hostname)) {
-                            return `${escapeHTML(leading)}<a href="${escapeHTML(core)}" rel="nofollow">`
-                            + `${escapeHTML(core)}</a>${escapeHTML(trailing)}`;
+                            return `${escapeHTML(leading)}${escapeHTML(textBefore)}`
+                                + `<a href="${escapeHTML(urlCandidate)}" rel="nofollow">`
+                                + `${escapeHTML(urlCandidate)}</a>${escapeHTML(trailing)}`;
                         }
                     } catch {
                         // ignore invalid URL parsing
                     }
 
                     // fallback: link the prefix part (no strict domain validation)
-                    const match = core.match(/^([a-zA-Z]+:\/\/([a-zA-Z0-9-]+))/);
+                    const match = urlCandidate.match(/^([a-zA-Z]+:\/\/([a-zA-Z0-9-]+))/);
                     if (match) {
                         const full = match[1];
                         const host = match[2];
 
                         // reject invalid host patterns
                         if (!host.startsWith('-') && /^[a-zA-Z0-9-]+$/.test(host)) {
-                            const rest = core.slice(full.length);
-                            return `${escapeHTML(leading)}<a href="${escapeHTML(full)}" rel="nofollow">`
-                            + `${escapeHTML(full)}</a>${escapeHTML(rest + trailing)}`;
+                            const rest = urlCandidate.slice(full.length);
+                            return `${escapeHTML(leading)}${escapeHTML(textBefore)}`
+                                + `<a href="${escapeHTML(full)}" rel="nofollow">`
+                                + `${escapeHTML(full)}</a>${escapeHTML(rest + trailing)}`;
                         }
                     }
 
-                    return escapeHTML(chunk);
+                    return `${escapeHTML(leading)}${escapeHTML(core)}${escapeHTML(trailing)}`;
                 }
 
                 // domain (e.g. abc.com, www.google.com)
-                const domainMatch = core.match(/^((?:www\.)?[a-zA-Z0-9-]+\.[a-zA-Z]{2,})(?=$|[^a-zA-Z0-9-])/);
-                if (domainMatch) {
-                    const domain = domainMatch[1];
-                    const host = domain.replace(/^www\./, '');
+                const domainIdx = core.search(/(?:www\.)?[a-zA-Z0-9-]+\.[a-zA-Z]{2,}/);
+                if (domainIdx >= 0) {
+                    const textBefore = core.slice(0, domainIdx);
+                    const urlCandidate = core.slice(domainIdx);
 
-                    if (isValidDomain(host)) {
-                        const rest = core.slice(domain.length);
-                        return `${escapeHTML(leading)}<a href="http://${escapeHTML(domain)}" rel="nofollow">`
-                        + `${escapeHTML(domain)}</a>${escapeHTML(rest + trailing)}`;
+                    const domainMatchRegex = /^((?:www\.)?[a-zA-Z0-9-]+\.[a-zA-Z]{2,})(?=$|[^a-zA-Z0-9-])/;
+                    const domainMatch = urlCandidate.match(domainMatchRegex);
+                    if (domainMatch) {
+                        const domain = domainMatch[1];
+                        const host = domain.replace(/^www\./, '');
+
+                        if (isValidDomain(host)) {
+                            const rest = urlCandidate.slice(domain.length);
+                            return `${escapeHTML(leading)}${escapeHTML(textBefore)}`
+                                + `<a href="http://${escapeHTML(domain)}" rel="nofollow">`
+                                + `${escapeHTML(domain)}</a>${escapeHTML(rest + trailing)}`;
+                        }
                     }
                 }
 

--- a/lib/osf-components/addon/components/maintenance-banner/component.ts
+++ b/lib/osf-components/addon/components/maintenance-banner/component.ts
@@ -14,7 +14,6 @@ import CurrentUser from 'ember-osf-web/services/current-user';
 
 import {
     escapeHTML,
-    isEmail,
     isValidDomain,
     trimEdges,
 } from 'ember-osf-web/utils/string-utils';
@@ -109,67 +108,38 @@ export default class MaintenanceBanner extends Component {
                 // extract surrounding punctuation
                 const { leading, core, trailing } = trimEdges(chunk);
 
-                if (isEmail(core)) {
-                    return `${escapeHTML(leading)}<a href="mailto:${escapeHTML(core)}">`
-                        + `${escapeHTML(core)}</a>${escapeHTML(trailing)}`;
-                }
-
-                // scheme:// (loose handling, e.g. htp://)
-                const schemeIdx = core.search(/[a-zA-Z]+:\/\//);
+                // https:// or http:// URLs only
+                const schemeIdx = core.search(/https?:\/\//);
                 if (schemeIdx >= 0) {
                     const textBefore = core.slice(0, schemeIdx);
-                    const urlCandidate = core.slice(schemeIdx);
+                    const rest = core.slice(schemeIdx);
+
+                    // Extract URL portion: stop at whitespace, HTML chars, and Japanese brackets
+                    const urlMatch = /^(https?:\/\/[^\s<>"'【（「『〔】）」』〕、。]*)/.exec(rest);
+                    if (!urlMatch) {
+                        return escapeHTML(leading + core + trailing);
+                    }
+
+                    const urlRaw = urlMatch[1];
+                    const textAfter = rest.slice(urlRaw.length);
+
+                    // Strip trailing ASCII punctuation and unbalanced brackets from URL
+                    const { core: urlFinal, trailing: urlTrailing } = trimEdges(urlRaw);
 
                     try {
-                        const fake = urlCandidate.replace(/^([a-zA-Z]+):\/\//, 'http://');
-                        const u = new URL(fake);
+                        const u = new URL(urlFinal);
 
                         if (isValidDomain(u.hostname)) {
                             return `${escapeHTML(leading)}${escapeHTML(textBefore)}`
-                                + `<a href="${escapeHTML(urlCandidate)}" rel="nofollow">`
-                                + `${escapeHTML(urlCandidate)}</a>${escapeHTML(trailing)}`;
+                                + `<a href="${escapeHTML(urlFinal)}" rel="nofollow">`
+                                + `${escapeHTML(urlFinal)}</a>`
+                                + `${escapeHTML(urlTrailing + textAfter + trailing)}`;
                         }
                     } catch {
                         // ignore invalid URL parsing
                     }
 
-                    // fallback: link the prefix part (no strict domain validation)
-                    const match = urlCandidate.match(/^([a-zA-Z]+:\/\/([a-zA-Z0-9-]+))/);
-                    if (match) {
-                        const full = match[1];
-                        const host = match[2];
-
-                        // reject invalid host patterns
-                        if (!host.startsWith('-') && /^[a-zA-Z0-9-]+$/.test(host)) {
-                            const rest = urlCandidate.slice(full.length);
-                            return `${escapeHTML(leading)}${escapeHTML(textBefore)}`
-                                + `<a href="${escapeHTML(full)}" rel="nofollow">`
-                                + `${escapeHTML(full)}</a>${escapeHTML(rest + trailing)}`;
-                        }
-                    }
-
                     return `${escapeHTML(leading)}${escapeHTML(core)}${escapeHTML(trailing)}`;
-                }
-
-                // domain (e.g. abc.com, www.google.com)
-                const domainIdx = core.search(/(?:www\.)?[a-zA-Z0-9-]+\.[a-zA-Z]{2,}/);
-                if (domainIdx >= 0) {
-                    const textBefore = core.slice(0, domainIdx);
-                    const urlCandidate = core.slice(domainIdx);
-
-                    const domainMatchRegex = /^((?:www\.)?[a-zA-Z0-9-]+\.[a-zA-Z]{2,})(?=$|[^a-zA-Z0-9-])/;
-                    const domainMatch = urlCandidate.match(domainMatchRegex);
-                    if (domainMatch) {
-                        const domain = domainMatch[1];
-                        const host = domain.replace(/^www\./, '');
-
-                        if (isValidDomain(host)) {
-                            const rest = urlCandidate.slice(domain.length);
-                            return `${escapeHTML(leading)}${escapeHTML(textBefore)}`
-                                + `<a href="http://${escapeHTML(domain)}" rel="nofollow">`
-                                + `${escapeHTML(domain)}</a>${escapeHTML(rest + trailing)}`;
-                        }
-                    }
                 }
 
                 return escapeHTML(chunk);

--- a/lib/osf-components/addon/components/maintenance-banner/template.hbs
+++ b/lib/osf-components/addon/components/maintenance-banner/template.hbs
@@ -6,7 +6,7 @@
     >
         <strong>{{t 'maintenance.title'}}</strong>
         {{#if this.maintenance.message.length}}
-            {{this.maintenance.message}}
+            {{this.renderedMessage}}
         {{else}}
             {{t 'maintenance.line1' start=this.start end=this.end utc=this.utc htmlSafe=true}}
             {{t 'maintenance.line2'}}

--- a/tests/integration/components/maintenance-banner/component-test.ts
+++ b/tests/integration/components/maintenance-banner/component-test.ts
@@ -36,4 +36,71 @@ module('Integration | Component | maintenance-banner', hooks => {
         await render(hbs`{{maintenance-banner}}`);
         assert.dom('.alert').includesText('longstringy');
     });
+
+    test('it renders line breaks as <br>', async assert => {
+        server.urlPrefix = apiUrl;
+        server.namespace = '/v2';
+        server.get('/status', () => ({
+            maintenance: {
+                message: 'line1\nline2',
+                level: 1,
+            },
+        }));
+
+        await render(hbs`{{maintenance-banner}}`);
+
+        assert.dom('.alert').hasTextContaining('line1');
+        assert.dom('.alert').hasTextContaining('line2');
+        assert.dom('.alert br').exists({ count: 1 });
+    });
+
+    test('it converts URLs to clickable links', async assert => {
+        server.urlPrefix = apiUrl;
+        server.namespace = '/v2';
+        server.get('/status', () => ({
+            maintenance: {
+                message: 'Visit https://abc-test.com',
+                level: 1,
+            },
+        }));
+
+        await render(hbs`{{maintenance-banner}}`);
+
+        assert.dom('.alert a')
+            .hasAttribute('href', 'https://abc-test.com')
+            .hasText('https://abc-test.com');
+    });
+
+    test('it escapes HTML to prevent XSS', async assert => {
+        server.urlPrefix = apiUrl;
+        server.namespace = '/v2';
+        server.get('/status', () => ({
+            maintenance: {
+                message: '<script>alert("xss")</script>',
+                level: 1,
+            },
+        }));
+
+        await render(hbs`{{maintenance-banner}}`);
+
+        assert.dom('.alert script').doesNotExist();
+        assert.dom('.alert').includesText('<script>alert("xss")</script>');
+    });
+
+    test('it handles mixed content (text + url + newline)', async assert => {
+        server.urlPrefix = apiUrl;
+        server.namespace = '/v2';
+        server.get('/status', () => ({
+            maintenance: {
+                message: 'line1\nhttps://abc-test.com\nline3',
+                level: 1,
+            },
+        }));
+
+        await render(hbs`{{maintenance-banner}}`);
+
+        assert.dom('.alert br').exists({ count: 2 });
+        assert.dom('.alert a').exists({ count: 1 });
+        assert.dom('.alert a').hasAttribute('href', 'https://abc-test.com');
+    });
 });

--- a/tests/integration/components/maintenance-banner/component-test.ts
+++ b/tests/integration/components/maintenance-banner/component-test.ts
@@ -15,10 +15,13 @@ module('Integration | Component | maintenance-banner', hooks => {
     setupMirage(hooks);
 
     test('it renders no maintenance', async assert => {
-        server.get('/v2/status', () => ({
+        server.urlPrefix = apiUrl;
+        server.namespace = '/v2';
+        server.get('/status', () => ({
             meta: { version: '2.8' },
             maintenance: null,
         }));
+
         await render(hbs`{{maintenance-banner}}`);
         assert.dom('.alert').doesNotExist();
     });
@@ -26,6 +29,7 @@ module('Integration | Component | maintenance-banner', hooks => {
     test('it renders maintenance message', async assert => {
         server.urlPrefix = apiUrl;
         server.namespace = '/v2';
+
         server.get('/status', () => ({
             meta: { version: '2.8' },
             maintenance: {
@@ -33,6 +37,7 @@ module('Integration | Component | maintenance-banner', hooks => {
                 level: 1,
             },
         }));
+
         await render(hbs`{{maintenance-banner}}`);
         assert.dom('.alert').includesText('longstringy');
     });
@@ -41,6 +46,7 @@ module('Integration | Component | maintenance-banner', hooks => {
         server.urlPrefix = apiUrl;
         server.namespace = '/v2';
         server.get('/status', () => ({
+            meta: { version: '2.8' },
             maintenance: {
                 message: 'line1\nline2',
                 level: 1,
@@ -49,34 +55,16 @@ module('Integration | Component | maintenance-banner', hooks => {
 
         await render(hbs`{{maintenance-banner}}`);
 
-        assert.dom('.alert').hasTextContaining('line1');
-        assert.dom('.alert').hasTextContaining('line2');
         assert.dom('.alert br').exists({ count: 1 });
-    });
-
-    test('it converts URLs to clickable links', async assert => {
-        server.urlPrefix = apiUrl;
-        server.namespace = '/v2';
-        server.get('/status', () => ({
-            maintenance: {
-                message: 'Visit https://abc-test.com',
-                level: 1,
-            },
-        }));
-
-        await render(hbs`{{maintenance-banner}}`);
-
-        assert.dom('.alert a')
-            .hasAttribute('href', 'https://abc-test.com')
-            .hasText('https://abc-test.com');
     });
 
     test('it escapes HTML to prevent XSS', async assert => {
         server.urlPrefix = apiUrl;
         server.namespace = '/v2';
         server.get('/status', () => ({
+            meta: { version: '2.8' },
             maintenance: {
-                message: '<script>alert("xss")</script>',
+                message: '<script>alert(1)</script>',
                 level: 1,
             },
         }));
@@ -84,15 +72,121 @@ module('Integration | Component | maintenance-banner', hooks => {
         await render(hbs`{{maintenance-banner}}`);
 
         assert.dom('.alert script').doesNotExist();
-        assert.dom('.alert').includesText('<script>alert("xss")</script>');
+        assert.dom('.alert').includesText('<script>alert(1)</script>');
+    });
+
+    test('it converts email to mailto link', async assert => {
+        server.urlPrefix = apiUrl;
+        server.namespace = '/v2';
+        server.get('/status', () => ({
+            meta: { version: '2.8' },
+            maintenance: {
+                message: 'test@example.com',
+                level: 1,
+            },
+        }));
+
+        await render(hbs`{{maintenance-banner}}`);
+
+        assert.dom('.alert a')
+            .hasAttribute('href', 'mailto:test@example.com')
+            .hasText('test@example.com');
+    });
+
+    test('it converts valid URL to link', async assert => {
+        server.urlPrefix = apiUrl;
+        server.namespace = '/v2';
+        server.get('/status', () => ({
+            meta: { version: '2.8' },
+            maintenance: {
+                message: 'https://google.com',
+                level: 1,
+            },
+        }));
+
+        await render(hbs`{{maintenance-banner}}`);
+
+        assert.dom('.alert a')
+            .hasAttribute('href', 'https://google.com')
+            .hasText('https://google.com');
+    });
+
+    test('it supports loose scheme (htp:// still becomes link)', async assert => {
+        server.urlPrefix = apiUrl;
+        server.namespace = '/v2';
+        server.get('/status', () => ({
+            meta: { version: '2.8' },
+            maintenance: {
+                message: 'htp://google.com',
+                level: 1,
+            },
+        }));
+
+        await render(hbs`{{maintenance-banner}}`);
+
+        assert.dom('.alert a')
+            .hasAttribute('href', 'htp://google.com')
+            .hasText('htp://google.com');
+    });
+
+    test('it does NOT link invalid domain', async assert => {
+        server.urlPrefix = apiUrl;
+        server.namespace = '/v2';
+        server.get('/status', () => ({
+            meta: { version: '2.8' },
+            maintenance: {
+                message: 'http://-google...com',
+                level: 1,
+            },
+        }));
+
+        await render(hbs`{{maintenance-banner}}`);
+
+        assert.dom('.alert a').doesNotExist();
+        assert.dom('.alert').includesText('http://-google...com');
+    });
+
+    test('it converts domain without scheme', async assert => {
+        server.urlPrefix = apiUrl;
+        server.namespace = '/v2';
+        server.get('/status', () => ({
+            meta: { version: '2.8' },
+            maintenance: {
+                message: 'abc.com',
+                level: 1,
+            },
+        }));
+
+        await render(hbs`{{maintenance-banner}}`);
+
+        assert.dom('.alert a')
+            .hasAttribute('href', 'http://abc.com')
+            .hasText('abc.com');
+    });
+
+    test('it handles partial broken URL (g<>gle.com)', async assert => {
+        server.urlPrefix = apiUrl;
+        server.namespace = '/v2';
+        server.get('/status', () => ({
+            meta: { version: '2.8' },
+            maintenance: {
+                message: 'http://g<>gle.com',
+                level: 1,
+            },
+        }));
+
+        await render(hbs`{{maintenance-banner}}`);
+
+        assert.dom('.alert a').exists({ count: 2 });
     });
 
     test('it handles mixed content (text + url + newline)', async assert => {
         server.urlPrefix = apiUrl;
         server.namespace = '/v2';
         server.get('/status', () => ({
+            meta: { version: '2.8' },
             maintenance: {
-                message: 'line1\nhttps://abc-test.com\nline3',
+                message: 'line1\nhttps://abc.com\nline3',
                 level: 1,
             },
         }));
@@ -101,6 +195,24 @@ module('Integration | Component | maintenance-banner', hooks => {
 
         assert.dom('.alert br').exists({ count: 2 });
         assert.dom('.alert a').exists({ count: 1 });
-        assert.dom('.alert a').hasAttribute('href', 'https://abc-test.com');
+    });
+
+    test('it handles URL surrounded by parentheses', async assert => {
+        server.urlPrefix = apiUrl;
+        server.namespace = '/v2';
+        server.get('/status', () => ({
+            meta: { version: '2.8' },
+            maintenance: {
+                message: 'Please visit (https://google.com) for more info.',
+                level: 1,
+            },
+        }));
+
+        await render(hbs`{{maintenance-banner}}`);
+
+        assert.dom('.alert a')
+            .hasAttribute('href', 'https://google.com')
+            .hasText('https://google.com');
+        assert.dom('.alert').includesText('Please visit (https://google.com) for more info.');
     });
 });

--- a/tests/integration/components/maintenance-banner/component-test.ts
+++ b/tests/integration/components/maintenance-banner/component-test.ts
@@ -75,24 +75,6 @@ module('Integration | Component | maintenance-banner', hooks => {
         assert.dom('.alert').includesText('<script>alert(1)</script>');
     });
 
-    test('it converts email to mailto link', async assert => {
-        server.urlPrefix = apiUrl;
-        server.namespace = '/v2';
-        server.get('/status', () => ({
-            meta: { version: '2.8' },
-            maintenance: {
-                message: 'test@example.com',
-                level: 1,
-            },
-        }));
-
-        await render(hbs`{{maintenance-banner}}`);
-
-        assert.dom('.alert a')
-            .hasAttribute('href', 'mailto:test@example.com')
-            .hasText('test@example.com');
-    });
-
     test('it converts valid URL to link', async assert => {
         server.urlPrefix = apiUrl;
         server.namespace = '/v2';
@@ -111,24 +93,6 @@ module('Integration | Component | maintenance-banner', hooks => {
             .hasText('https://google.com');
     });
 
-    test('it supports loose scheme (htp:// still becomes link)', async assert => {
-        server.urlPrefix = apiUrl;
-        server.namespace = '/v2';
-        server.get('/status', () => ({
-            meta: { version: '2.8' },
-            maintenance: {
-                message: 'htp://google.com',
-                level: 1,
-            },
-        }));
-
-        await render(hbs`{{maintenance-banner}}`);
-
-        assert.dom('.alert a')
-            .hasAttribute('href', 'htp://google.com')
-            .hasText('htp://google.com');
-    });
-
     test('it does NOT link invalid domain', async assert => {
         server.urlPrefix = apiUrl;
         server.namespace = '/v2';
@@ -144,40 +108,6 @@ module('Integration | Component | maintenance-banner', hooks => {
 
         assert.dom('.alert a').doesNotExist();
         assert.dom('.alert').includesText('http://-google...com');
-    });
-
-    test('it converts domain without scheme', async assert => {
-        server.urlPrefix = apiUrl;
-        server.namespace = '/v2';
-        server.get('/status', () => ({
-            meta: { version: '2.8' },
-            maintenance: {
-                message: 'abc.com',
-                level: 1,
-            },
-        }));
-
-        await render(hbs`{{maintenance-banner}}`);
-
-        assert.dom('.alert a')
-            .hasAttribute('href', 'http://abc.com')
-            .hasText('abc.com');
-    });
-
-    test('it handles partial broken URL (g<>gle.com)', async assert => {
-        server.urlPrefix = apiUrl;
-        server.namespace = '/v2';
-        server.get('/status', () => ({
-            meta: { version: '2.8' },
-            maintenance: {
-                message: 'http://g<>gle.com',
-                level: 1,
-            },
-        }));
-
-        await render(hbs`{{maintenance-banner}}`);
-
-        assert.dom('.alert a').exists({ count: 2 });
     });
 
     test('it handles mixed content (text + url + newline)', async assert => {

--- a/tests/unit/utils/string-utils-test.ts
+++ b/tests/unit/utils/string-utils-test.ts
@@ -1,0 +1,76 @@
+import {
+    escapeHTML,
+    isEmail,
+    isValidDomain,
+    trimEdges,
+} from 'ember-osf-web/utils/string-utils';
+
+import { module, test } from 'qunit';
+
+module('Unit | Utility | string-utils', () => {
+    test('escapeHTML escapes dangerous characters', assert => {
+        const cases: Array<[string, string]> = [
+            ['', ''],
+            ['abc', 'abc'],
+            ['<script>', '&lt;script&gt;'],
+            ['Tom & Jerry', 'Tom &amp; Jerry'],
+            ['"quote"', '&quot;quote&quot;'],
+            ["'single'", '&#39;single&#39;'],
+            ['<>&"\'', '&lt;&gt;&amp;&quot;&#39;'],
+        ];
+
+        for (const [input, expected] of cases) {
+            assert.strictEqual(escapeHTML(input), expected);
+        }
+    });
+
+    test('isEmail validates email correctly', assert => {
+        const cases: Array<[string, boolean]> = [
+            ['test@example.com', true],
+            ['user.name+tag@gmail.com', true],
+            ['invalid-email', false],
+            ['abc@', false],
+            ['@domain.com', false],
+            ['abc@domain', false],
+        ];
+
+        for (const [input, expected] of cases) {
+            assert.strictEqual(isEmail(input), expected);
+        }
+    });
+
+    test('isValidDomain validates domain correctly', assert => {
+        const cases: Array<[string, boolean]> = [
+            ['google.com', true],
+            ['sub.domain.com', true],
+            ['abc.co', true],
+            ['-google.com', false],
+            ['google-.com', false],
+            ['google..com', false],
+            ['google', false],
+            ['g<>gle.com', false],
+            ['??', false],
+        ];
+
+        for (const [input, expected] of cases) {
+            assert.strictEqual(isValidDomain(input), expected);
+        }
+    });
+
+    test('trimEdges splits leading and trailing punctuation', assert => {
+        const cases: Array<[string, { leading: string; core: string; trailing: string }]> = [
+            ['', { leading: '', core: '', trailing: '' }],
+            ['abc', { leading: '', core: 'abc', trailing: '' }],
+            ['(abc)', { leading: '(', core: 'abc', trailing: ')' }],
+            ['[(abc)]', { leading: '[(', core: 'abc', trailing: ')]' }],
+            ['(https://google.com)', { leading: '(', core: 'https://google.com', trailing: ')' }],
+        ];
+
+        for (const [input, expected] of cases) {
+            const result = trimEdges(input);
+            assert.strictEqual(result.leading, expected.leading);
+            assert.strictEqual(result.core, expected.core);
+            assert.strictEqual(result.trailing, expected.trailing);
+        }
+    });
+});

--- a/tests/unit/utils/string-utils-test.ts
+++ b/tests/unit/utils/string-utils-test.ts
@@ -1,6 +1,5 @@
 import {
     escapeHTML,
-    isEmail,
     isValidDomain,
     trimEdges,
 } from 'ember-osf-web/utils/string-utils';
@@ -21,21 +20,6 @@ module('Unit | Utility | string-utils', () => {
 
         for (const [input, expected] of cases) {
             assert.strictEqual(escapeHTML(input), expected);
-        }
-    });
-
-    test('isEmail validates email correctly', assert => {
-        const cases: Array<[string, boolean]> = [
-            ['test@example.com', true],
-            ['user.name+tag@gmail.com', true],
-            ['invalid-email', false],
-            ['abc@', false],
-            ['@domain.com', false],
-            ['abc@domain', false],
-        ];
-
-        for (const [input, expected] of cases) {
-            assert.strictEqual(isEmail(input), expected);
         }
     });
 


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [GRDM-57869]
- Feature flag: n/a

## Purpose

 - Allow maintenance alert message display in multi-line.
 - Automatically detect URLs in messages.

## Summary of Changes

- Add the renderedMessage function to process the maintenance message before displaying it on the screen.

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
