### PR TITLE
[GRDM-57855] Prevent auto-submitting Project/Collection when confirming Japanese IME input with Enter

### DIFF
--- a/lib/osf-components/addon/components/new-project-modal/component.ts
+++ b/lib/osf-components/addon/components/new-project-modal/component.ts
@@ -217,14 +217,16 @@ export default class NewProjectModal extends Component {
     }
 
     @action
-    handleKeydown(event: KeyboardEvent & {
-        isComposing?: boolean;
-        keyCode?: number; }) {
+    handleKeydown(_: string, event: KeyboardEvent & { isComposing?: boolean }) {
+        if (!event) {
+            return;
+        }
+
         const isIME = event.isComposing || event.keyCode === 229;
         if (isIME) {
             return;
         }
-        if (event.key === 'Enter') {
+        if (event.key === 'Enter' && this.nodeTitle && this.nodeTitle.trim()) {
             event.preventDefault();
             this.create();
         }

--- a/lib/osf-components/addon/components/new-project-modal/component.ts
+++ b/lib/osf-components/addon/components/new-project-modal/component.ts
@@ -215,4 +215,18 @@ export default class NewProjectModal extends Component {
     searchNodes(this: NewProjectModal, searchTerm: string) {
         return this.get('searchUserNodesTask').perform(searchTerm);
     }
+
+    @action
+    handleKeydown(event: KeyboardEvent & {
+        isComposing?: boolean;
+        keyCode?: number; }) {
+        const isIME = event.isComposing || event.keyCode === 229;
+        if (isIME) {
+            return;
+        }
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            this.create();
+        }
+    }
 }

--- a/lib/osf-components/addon/components/new-project-modal/template.hbs
+++ b/lib/osf-components/addon/components/new-project-modal/template.hbs
@@ -41,7 +41,7 @@
                                 @required={{true}}
                                 @value={{this.nodeTitle}}
                                 @type='text'
-                                @keyDown={{action this.handleKeydown}}
+                                @key-down={{action this.handleKeydown}}
                             />
                         </label>
                     </div>

--- a/lib/osf-components/addon/components/new-project-modal/template.hbs
+++ b/lib/osf-components/addon/components/new-project-modal/template.hbs
@@ -41,7 +41,7 @@
                                 @required={{true}}
                                 @value={{this.nodeTitle}}
                                 @type='text'
-                                @enter={{action this.create}}
+                                @keyDown={{action this.handleKeydown}}
                             />
                         </label>
                     </div>

--- a/tests/integration/components/new-project-modal/component-test.ts
+++ b/tests/integration/components/new-project-modal/component-test.ts
@@ -1,115 +1,129 @@
 import { A } from '@ember/array';
+import EmberObject, { action } from '@ember/object';
 import Service from '@ember/service';
-import {
-    fillIn,
-    render,
-    triggerEvent,
-} from '@ember/test-helpers';
+import { fillIn, render, triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
+import Promise from 'rsvp';
 import sinon from 'sinon';
 
-const currentUserStub = Service.extend({
-    user: Object.freeze({
-        institutions: A([]),
-    }),
-});
+import NewProjectModal from 'osf-components/components/new-project-modal/component';
+
+interface LocalTestContext extends TestContext {
+    createActionSpy: sinon.SinonSpy;
+}
+
+let createSpyPlaceholder: sinon.SinonSpy | undefined;
+
+class MockNewProjectModal extends NewProjectModal {
+    @action
+    create(this: any, ...args: any[]) {
+        if (createSpyPlaceholder) {
+            createSpyPlaceholder(...args);
+        }
+    }
+}
 
 module('Integration | Component | new-project-modal', hooks => {
     setupRenderingTest(hooks);
 
-    hooks.beforeEach(function(this: TestContext) {
-        this.owner.register(
-            'service:current-user',
-            currentUserStub,
-        );
+    hooks.beforeEach(function(this: LocalTestContext) {
+        this.createActionSpy = sinon.spy();
+        createSpyPlaceholder = this.createActionSpy;
+
+        this.owner.register('component:new-project-modal', MockNewProjectModal);
+
+        const mockUser = EmberObject.create({
+            institutions: A([EmberObject.create({ id: 'mock' })]),
+            defaultRegion: EmberObject.create({ id: 'us' }),
+        });
+
+        this.owner.register('service:current-user', Service.extend({ user: mockUser }));
+        this.owner.register('service:features', Service.extend({ isEnabled: () => false }));
+        this.owner.register('service:intl', Service.extend({ t: (key: string) => key }));
+        this.owner.register('service:toast', Service.extend({ error: sinon.spy(), success: sinon.spy() }));
+        this.owner.register('service:analytics', Service.extend({ click: sinon.spy() }));
+        this.owner.register('service:store', Service.extend({
+            findAll() { return Promise.resolve(A([])); },
+        }));
+    });
+
+    hooks.afterEach(() => {
+        createSpyPlaceholder = undefined;
     });
 
     test('it renders', async assert => {
         await render(hbs`
-            <NewProjectModal />
+            <NewProjectModal @afterProjectCreated={{this.afterProjectCreatedSpy}} />
         `);
-
         assert.dom('.modal').exists();
-        assert.dom('.modal-title')
-            .hasText('Create new project');
+        assert.dom('.modal-title').hasText('Create new project');
     });
 
     test('create button is disabled initially', async assert => {
         await render(hbs`
-            <NewProjectModal />
+            <NewProjectModal @afterProjectCreated={{this.afterProjectCreatedSpy}} />
         `);
-
-        assert.dom(
-            '[data-test-create-project-submit]',
-        ).isDisabled();
+        assert.dom('[data-test-create-project-submit]').isDisabled();
     });
 
-    test('create button is enabled after input', async assert => {
+    test('it renders and initializes correctly', async assert => {
         await render(hbs`
-            <NewProjectModal />
+            <NewProjectModal @afterProjectCreated={{this.afterProjectCreatedSpy}} />
         `);
 
-        await fillIn(
-            '[data-test-new-project-title]',
-            'Hello World',
-        );
-
-        assert.dom(
-            '[data-test-create-project-submit]',
-        ).isEnabled();
+        assert.dom('[data-test-new-project-title]').exists('Input fields for project title exists');
     });
 
-    test('Enter triggers create when not composing', function(this: TestContext, assert) {
-        const component = this.owner.factoryFor(
-            'component:new-project-modal',
-        )!.create() as any;
+    test(
+        'Enter key triggers create action through DOM binding when not composing',
+        async function(this: LocalTestContext, assert) {
+            await render(hbs`
+                <NewProjectModal />
+            `);
 
-        let prevented = false;
+            const inputSelector = '[data-test-new-project-title]';
+            assert.dom(inputSelector).exists('Input field must exist');
 
-        component.handleKeydown({
-            key: 'Enter',
-            isComposing: false,
-            keyCode: 13,
-            preventDefault() {
-                prevented = true;
-            },
-        });
+            await fillIn(inputSelector, 'My Awesome New Project');
 
-        assert.ok(prevented);
-    });
+            await triggerKeyEvent(inputSelector, 'keydown', 'Enter');
 
-    test('IME Enter does not trigger create', async function(this: TestContext, assert) {
-        await render(hbs`
-            <NewProjectModal />
-        `);
+            assert.ok(
+                this.createActionSpy.calledOnce,
+                'The create() action on the component should be triggered.',
+            );
+        },
+    );
 
-        const component = this.owner.lookup(
-            'component:new-project-modal',
-        );
+    test(
+        'Enter key does NOT trigger create action when Japanese IME is composing',
+        async function(this: LocalTestContext, assert) {
+            await render(hbs`
+                <NewProjectModal />
+            `);
 
-        const createStub = sinon.stub(
-            component,
-            'create',
-        );
+            const inputSelector = '[data-test-new-project-title]';
+            assert.dom(inputSelector).exists();
 
-        const input = document.querySelector(
-            '[data-test-new-project-title]',
-        ) as HTMLInputElement;
+            await fillIn(inputSelector, 'プロジェクト');
 
-        await fillIn(
-            '[data-test-new-project-title]',
-            'プロジェクト',
-        );
+            await triggerEvent(inputSelector, 'keydown', {
+                key: 'Enter',
+                code: 'Enter',
+                keyCode: 229,
+                which: 229,
+                isComposing: true,
+                bubbles: true,
+                cancelable: true,
+            } as any);
 
-        await triggerEvent(input, 'keydown', {
-            key: 'Enter',
-            isComposing: true,
-            keyCode: 229,
-        });
-
-        assert.ok(createStub.notCalled);
-    });
+            assert.notOk(
+                this.createActionSpy.called,
+                'The create() action must NOT be triggered during IME composition.',
+            );
+        },
+    );
 });

--- a/tests/integration/components/new-project-modal/component-test.ts
+++ b/tests/integration/components/new-project-modal/component-test.ts
@@ -1,10 +1,15 @@
 import { A } from '@ember/array';
 import Service from '@ember/service';
-import { render } from '@ember/test-helpers';
+import {
+    fillIn,
+    render,
+    triggerEvent,
+} from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 const currentUserStub = Service.extend({
     user: Object.freeze({
@@ -16,12 +21,95 @@ module('Integration | Component | new-project-modal', hooks => {
     setupRenderingTest(hooks);
 
     hooks.beforeEach(function(this: TestContext) {
-        this.owner.register('service:current-user', currentUserStub);
+        this.owner.register(
+            'service:current-user',
+            currentUserStub,
+        );
     });
 
     test('it renders', async assert => {
-        await render(hbs`<NewProjectModal />`);
+        await render(hbs`
+            <NewProjectModal />
+        `);
+
         assert.dom('.modal').exists();
-        assert.dom('.modal-title').hasText('Create new project');
+        assert.dom('.modal-title')
+            .hasText('Create new project');
+    });
+
+    test('create button is disabled initially', async assert => {
+        await render(hbs`
+            <NewProjectModal />
+        `);
+
+        assert.dom(
+            '[data-test-create-project-submit]',
+        ).isDisabled();
+    });
+
+    test('create button is enabled after input', async assert => {
+        await render(hbs`
+            <NewProjectModal />
+        `);
+
+        await fillIn(
+            '[data-test-new-project-title]',
+            'Hello World',
+        );
+
+        assert.dom(
+            '[data-test-create-project-submit]',
+        ).isEnabled();
+    });
+
+    test('Enter triggers create when not composing', function(this: TestContext, assert) {
+        const component = this.owner.factoryFor(
+            'component:new-project-modal',
+        )!.create() as any;
+
+        let prevented = false;
+
+        component.handleKeydown({
+            key: 'Enter',
+            isComposing: false,
+            keyCode: 13,
+            preventDefault() {
+                prevented = true;
+            },
+        });
+
+        assert.ok(prevented);
+    });
+
+    test('IME Enter does not trigger create', async function(this: TestContext, assert) {
+        await render(hbs`
+            <NewProjectModal />
+        `);
+
+        const component = this.owner.lookup(
+            'component:new-project-modal',
+        );
+
+        const createStub = sinon.stub(
+            component,
+            'create',
+        );
+
+        const input = document.querySelector(
+            '[data-test-new-project-title]',
+        ) as HTMLInputElement;
+
+        await fillIn(
+            '[data-test-new-project-title]',
+            'プロジェクト',
+        );
+
+        await triggerEvent(input, 'keydown', {
+            key: 'Enter',
+            isComposing: true,
+            keyCode: 229,
+        });
+
+        assert.ok(createStub.notCalled);
     });
 });


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [57855]
- Feature flag: n/a

## Purpose

The purpose of these changes is to fix an issue where pressing the Enter key to confirm Japanese IME (Input Method Editor) composition unintentionally triggers the creation of a Project. This fix ensures that users can completely type and confirm their Japanese input without the form submitting prematurely and creating entities with incomplete names.

## Summary of Changes

- lib/osf-components/addon/components/new-project-modal/component.ts: Added handleKeydown method.
- lib/osf-components/addon/components/new-project-modal/template.hbs: Updated to use the new keydown handler.
- tests/integration/components/new-project-modal/component-test.ts: Added new test cases for Enter key vs IME composition, improved mocks and setup.

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
