### PR TITLE
[GRDM-56496] 解析・メタデータタブ表示時に証跡管理タブが表示されない不具合を修正

### DIFF
--- a/lib/osf-components/addon/components/node-navbar/template.hbs
+++ b/lib/osf-components/addon/components/node-navbar/template.hbs
@@ -62,6 +62,9 @@
                         {{#if (if @node.isRegistration @node.userHasWritePermission @node.userHasReadPermission)}}
                             {{node-navbar/link node=@node useLinkTo=false destination='settings'}}
                         {{/if}}
+                        {{#if @node.userHasAdminPermission}}
+                            {{node-navbar/link node=@node useLinkTo=false destination='timestamp'}}
+                        {{/if}}
                     </ul>
                 </BsCollapse>
             </div>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -561,6 +561,7 @@ node_navbar:
     metadata: Metadata
     package: Export
     workflow: Workflow
+    timestamp: Timestamp
 status:
     welcome_message: '<h1>Welcome to GakuNin RDM!</h1><p>Visit our <a href="https://openscience.zendesk.com/hc/en-us" target="_blank" rel="noreferrer">Guides</a> to learn about creating a project, or get inspiration from <a href="https://osf.io/explore/activity/#popularPublicProjects">popular public projects</a>.</p>'
     alternate_email_error: 'The email address has <b>NOT</b> been added to your account. Please log out and revisit the link in your email. Thank you.'

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -561,6 +561,7 @@ node_navbar:
     metadata: メタデータ
     package: エクスポート
     workflow: ワークフロー
+    timestamp: 証跡管理
 status:
     welcome_message: '<h1>GakuNin RDMへようこそ!</h1><p><a href="https://openscience.zendesk.com/hc/en-us" target="_blank" rel="noreferrer">プロジェクトの作成方法について学ぶ</a>か、<a href="https://osf.io/explore/activity/#popularPublicProjects">一般的な公開プロジェクトからインスピレーションを得ます</a>。</p>'
     alternate_email_error: '<b>メールアドレスがアカウントに追加されていません</ b>。 ログアウトして、メールのリンクを再確認してください。 ありがとうございました。'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: GRDM-56496
- Feature flag: n/a

## Purpose

解析タブ・メタデータタブなど ember で描画されるページを表示している間、プロジェクトナビゲーションに証跡管理タブが表示されない不具合を修正する。

ember 側のプロジェクトナビゲーション (node-navbar) に証跡管理タブへのリンクが実装されていなかったことが原因。

## Summary of Changes

- node-navbar に証跡管理 (timestamp) タブを追加
- 表示条件は mako 側 (project_header.mako) と同様に、管理者権限を持つユーザーのみとした
- 証跡管理タブのラベル翻訳 (en: Timestamp / ja: 証跡管理) を追加

## Side Effects

なし。管理者ユーザーのプロジェクトナビゲーションに証跡管理タブが追加で表示されるのみ。

## QA Notes

None